### PR TITLE
Updates to TEC control and monitoring for DVT1a

### DIFF
--- a/motion_connector.py
+++ b/motion_connector.py
@@ -35,11 +35,13 @@ except Exception:  # pragma: no cover
 # constants for calculations
 SCALE_V = 0.0909
 SCALE_I = 0.25
-V_REF = 2.5
+V_REF = 2.459 # Should be 2.5V but empirical measurements don't match
 R_1 = 18000 #(R221)
 R_2 = 8160  #(R224)
-R_3 = 51100 #(R225)
-
+R_3 = 49900 #(R225)
+R230 = 300E3
+R234 = 300E3
+R_s = 0.020 #(R217)
 
 # Global loggers - will be configured by _configure_logging method
 logger = None
@@ -2392,18 +2394,17 @@ class MOTIONConnector(QObject):
         try:
             v, i, p, t, ok = motion_interface.console_module.tec_status()
 
-            R_TH = 1/((float(v) / (V_REF/2*R_3)) - 1/R_3 + 1/R_1) - R_2
+            R_TH = 1/((float(v) / (V_REF/2*R_3)) - 1/R_3 + 1/R_1) - R_2 # v = OUT1, VOUT1 from ADC
             Thermistor_Temp = np.interp(R_TH, self._data_RT[:,1][::-1], self._data_RT[:,0][::-1])
 
-            
-            R_SET = 1/((float(i) / (V_REF/2*R_3)) - 1/R_3 + 1/R_1) - R_2
+            R_SET = 1/((float(i) / (V_REF/2*R_3)) - 1/R_3 + 1/R_1) - R_2 # i = IN2P, TEMPSET from ADC
             SET_Temp = np.interp(R_SET, self._data_RT[:,1][::-1], self._data_RT[:,0][::-1])
 
-            self._tec_voltage   = round(float(Thermistor_Temp), 2)
-            self._tec_temp      = round(float(SET_Temp), 2)
-            self._tec_monC      = round(float(p), 3)
-            self._tec_monV      = round(float(t), 3)
-            self._tec_good      = bool(ok)
+            self._tec_voltage   = round(float(Thermistor_Temp), 2) # Measured thermistor temperature
+            self._tec_temp      = round(float(SET_Temp), 2) # Measured target setpiont
+            self._tec_monC      = round((float(p) - 0.5*V_REF) / (25*R_s), 3) # p = V_itec
+            self._tec_monV      = round((float(t) - 0.5*V_REF) * 4, 3) # t = V_vtec
+            self._tec_good      = bool(ok) # TMPGD pin (abs(OUT1-IN2P) < 100mV)
 
             # Long-run health sample -> goes ONLY to run.log
                 

--- a/pages/Demo.qml
+++ b/pages/Demo.qml
@@ -1199,7 +1199,7 @@ Rectangle {
                                             anchors.margins: 8
                                             spacing: 2
 
-                                            Text { text: "Setpoint (V)"; color: "#BDC3C7"; font.pixelSize: 11 }
+                                            Text { text: "Setpoint (°C)"; color: "#BDC3C7"; font.pixelSize: 11 }
                                             Text {
                                                 // Bind to your live value:
                                                 text: Number(MOTIONInterface.tecTemp || 0).toFixed(3)
@@ -1222,7 +1222,7 @@ Rectangle {
                                             anchors.margins: 8
                                             spacing: 2
 
-                                            Text { text: "Current (V)"; color: "#BDC3C7"; font.pixelSize: 11 }
+                                            Text { text: "Current (I)"; color: "#BDC3C7"; font.pixelSize: 11 }
                                             Text {
                                                 // Bind to your live value:
                                                 text: Number(MOTIONInterface.tecMonC || 0).toFixed(3)
@@ -1284,7 +1284,7 @@ Rectangle {
 
                                 // Left label (col 0)
                                 Text {
-                                    text: "TEC Temperature:"
+                                    text: "TEC Temperature:\nEVT2_25C ≈ +1.16V\nDVT1a_25C ≈ -0.07"
                                     color: "white"
                                     Layout.row: 1
                                     Layout.column: 0
@@ -1303,7 +1303,7 @@ Rectangle {
 
                                     // Small caption above the inputs (optional)
                                     Text {
-                                        text: "Setpoint (v)"
+                                        text: "DAC Setpoint (V)"
                                         color: "#BDC3C7"
                                         font.pixelSize: 12
                                     }
@@ -1323,10 +1323,10 @@ Rectangle {
                                             font.pixelSize: 12
                                             text: MOTIONInterface.tecDAC.toFixed(3)
 
-                                            // UI-level guard: only allow -5.00–5.00 volts
+                                            // UI-level guard: only allow -2.50–2.50 volts
                                             validator: DoubleValidator {
-                                                bottom: -5.0
-                                                top: 5.0
+                                                bottom: -2.5
+                                                top: 2.5
                                                 decimals: 6
                                                 notation: DoubleValidator.StandardNotation
                                             }
@@ -1353,8 +1353,8 @@ Rectangle {
                                             enabled: MOTIONInterface.consoleConnected
                                             onTriggered: {
                                                 const val = parseFloat(tecSetpoint.text)
-                                                if (isNaN(val) || val < -5.0 || val > 5.0) {
-                                                    console.error("Invalid TEC setpoint; must be -5.0000–5.0000 V")
+                                                if (isNaN(val) || val < -2.5 || val > 2.5) {
+                                                    console.error("Invalid TEC setpoint; must be -2.5000–2.5000 V")
                                                     return
                                                 }
                                     


### PR DESCRIPTION
Updating voltage divider changes around the DAC input to TEC controller. Updating monitoring current and voltage for TEC to be real units. Should now be all accurate for DVT1a. GUI DAC setpoint range reduced to +/-2.5V because using values outside of this don't have any meaningful output because TEC controller can only take in 0.05V to 2.46V at IN2P.

Also included target setpoints for both EVT2 and DVT1a units. Temperatures will not be accurate for EVT2 units with theses updates.