### PR TITLE
Adopt MotionInterface init kwargs (next-next → next)

### DIFF
--- a/motion_singleton.py
+++ b/motion_singleton.py
@@ -3,6 +3,18 @@
 # Single shared MotionInterface for the test app. The interface owns its
 # own connection-monitor daemon thread; ``main.py`` calls
 # ``motion_interface.start()`` once after the QML engine is loaded.
+import os
+
 from omotion import MotionInterface
 
-motion_interface = MotionInterface()
+# data_dir: SDK-managed outputs (corrected CSVs, telemetry) land next to the
+# histogram CSVs the connector writes.  scan_db_path=None because the test app
+# has no clinical scan database; operator_id identifies the source in logs.
+_data_dir = os.path.expanduser("~")
+os.makedirs(_data_dir, exist_ok=True)
+
+motion_interface = MotionInterface(
+    data_dir=_data_dir,
+    scan_db_path=None,
+    operator_id="test-app",
+)


### PR DESCRIPTION
Companion to openmotion-sdk PR #58 and openmotion-bloodflow-app PR #140. Supersedes #31 (targeted `next` directly before we standardized on the feature → next-next → next staging flow).

## What changed

`motion_singleton.py` now constructs `MotionInterface(data_dir=..., scan_db_path=..., operator_id=...)` so it's compatible with the new SDK's storage-sink auto-injection.

The test-app has no scan flow of its own (only manual triggers), so this is the entire migration needed for it.

## Tests

Test-app has no automated test suite. Verified by app launch on bench — connects, manual triggers fire, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)