### PR TITLE
chore: rename MOTIONInterface/MOTIONConnector to Motion*

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OpenMOTION Test Application
+# Open-Motion Test Application
 
 Python example UI for OPEN Motion used for Hardware Testing and Basic Usage
 
@@ -12,15 +12,15 @@ Python example UI for OPEN Motion used for Hardware Testing and Basic Usage
 ### Steps to Set Up the Project
 1. **Install OpenLIFU Python**
    ```bash
-   https://github.com/OpenwaterHealth/OpenMOTION-Pylib
-   cd OpenMOTION-Pylib
+   https://github.com/OpenwaterHealth/openmotion-sdk
+   cd openmotion-sdk
    pip install -r requirements.txt
    ```
 
 2. **Clone the repository and Install Required Packages**:
    ```bash
-   git clone https://github.com/OpenwaterHealth/OpenMOTION-TestAPP.git
-   cd OpenMOTION-TestAPP
+   git clone https://github.com/OpenwaterHealth/openmotion-test-app.git
+   cd openmotion-test-app
    pip install -r requirements.txt
    ```
 
@@ -32,10 +32,10 @@ Python example UI for OPEN Motion used for Hardware Testing and Basic Usage
    ```
 
 3. **Run application**
-   requires OpenMOTION-Pylib to be installed or referenced prior to running main.py
+   requires openmotion-sdk to be installed or referenced prior to running main.py
 
    ```bash
-   cd OpenMOTION-TestAPP
+   cd openmotion-test-app
    python main.py
    ```
 

--- a/components/ActionButton.qml
+++ b/components/ActionButton.qml
@@ -8,7 +8,7 @@ Button {
 
     // ——— Public API ———
     // Use `text` directly to set the label (standard Button property).
-    // Bind `enabled` from the outside as usual, e.g. enabled: MOTIONInterface.consoleConnected
+    // Bind `enabled` from the outside as usual, e.g. enabled: MotionInterface.consoleConnected
     signal triggered()
     property int cornerRadius: 4
     property color textColorEnabled:  "#BDC3C7"

--- a/components/HistogramView.qml
+++ b/components/HistogramView.qml
@@ -38,7 +38,7 @@ Item {
                     buttonText: "Export CSV"
                     onClicked: {
                         if (histogramWidget.histogramData.length > 0) {
-                            MOTIONConnector.saveHistogramToCSV(histogramWidget.histogramData)
+                            MotionConnector.saveHistogramToCSV(histogramWidget.histogramData)
                         }
                     }
                 }

--- a/fpga_laser_config.py
+++ b/fpga_laser_config.py
@@ -213,7 +213,7 @@ class FpgaModel:
 def load_laser_params(config_dir: str) -> list:
     """Load `laser_params.json` from the given config directory.
 
-    Mirrors the previous `_load_laser_params` behavior on MOTIONConnector.
+    Mirrors the previous `_load_laser_params` behavior on MotionConnector.
     Returns a list of parameter dicts, or an empty list on any error.
     """
     config_path = (

--- a/main.py
+++ b/main.py
@@ -6,11 +6,11 @@ import argparse
 from PyQt6.QtGui import QGuiApplication, QIcon
 from PyQt6.QtQml import QQmlApplicationEngine, qmlRegisterSingletonInstance
 
-from motion_connector import MOTIONConnector
+from motion_connector import MotionConnector
 from motion_singleton import motion_interface
 from version import get_version
 
-# set PYTHONPATH=%cd%\..\OpenMOTION-PyLib;%PYTHONPATH%
+# set PYTHONPATH=%cd%\..\openmotion-sdk;%PYTHONPATH%
 # python main.py
 
 APP_VERSION = get_version()
@@ -39,7 +39,7 @@ def resource_path(rel: str) -> str:
 
 def main():
     # Parse command line arguments
-    parser = argparse.ArgumentParser(description="OpenMOTION Test Application")
+    parser = argparse.ArgumentParser(description="Open-Motion Test Application")
     parser.add_argument(
         "--debug", action="store_true", help="Enable debug logging and console output"
     )
@@ -78,8 +78,8 @@ def main():
 
     # Expose to QML
     log_level = logging.DEBUG if args.debug else logging.INFO
-    connector = MOTIONConnector(log_level=log_level, github_disabled=args.no_github)
-    qmlRegisterSingletonInstance("OpenMotion", 1, 0, "MOTIONInterface", connector)
+    connector = MotionConnector(log_level=log_level, github_disabled=args.no_github)
+    qmlRegisterSingletonInstance("OpenMotion", 1, 0, "MotionInterface", connector)
     engine.rootContext().setContextProperty("appVersion", APP_VERSION)
     # Also expose app version on the QGuiApplication instance so Python
     # modules (not just QML) can read it via QGuiApplication.instance().property()
@@ -95,7 +95,7 @@ def main():
     # The SDK now owns its own daemon connection-monitor thread; no
     # asyncio loop required. start() returns once any already-attached
     # devices have completed their CONNECTING transition (or wait_timeout).
-    logger.info("Starting MOTION monitoring...")
+    logger.info("Starting Open-Motion monitoring...")
     motion_interface.start(wait=True, wait_timeout=2.0)
 
     def handle_exit():

--- a/main.qml
+++ b/main.qml
@@ -33,10 +33,10 @@ ApplicationWindow {
             anchors.right: parent.right
 
             // Set title and logo dynamically
-            titleText: "Open-MOTION Engineering App"
+            titleText: "Open-Motion Engineering App"
             logoSource: "../assets/images/OpenwaterLogo.png" // Correct relative path
             appVerText: "" + appVersion
-            sdkVerText: "" + MOTIONInterface.get_sdk_version()
+            sdkVerText: "" + MotionInterface.get_sdk_version()
         }
 
         // Layout for Sidebar and Main Content
@@ -87,6 +87,6 @@ ApplicationWindow {
     }
     
     Connections {
-        target: MOTIONInterface
+        target: MotionInterface
     }
 }

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -210,7 +210,7 @@ class _ConsoleFirmwareDownloadThread(QThread):
 
     def __init__(
         self,
-        connector: "MOTIONConnector",
+        connector: "MotionConnector",
         tag: str,
         filename: str,
         target: str = "console",
@@ -314,7 +314,7 @@ class _ConsoleFirmwareFlashThread(QThread):
     failed = pyqtSignal(str)
     finished_ok = pyqtSignal()
 
-    def __init__(self, connector: "MOTIONConnector", bin_path: str):
+    def __init__(self, connector: "MotionConnector", bin_path: str):
         super().__init__()
         self._connector = connector
         self._bin_path = bin_path
@@ -394,7 +394,7 @@ class _DeviceFirmwareFlashThread(QThread):
     failed = pyqtSignal(str)
     finished_ok = pyqtSignal()
 
-    def __init__(self, connector: "MOTIONConnector", bin_path: str, target: str):
+    def __init__(self, connector: "MotionConnector", bin_path: str, target: str):
         super().__init__()
         self._connector = connector
         self._bin_path = bin_path
@@ -491,7 +491,7 @@ class _ConsoleFpgaUpdateThread(QThread):
     finished_ok = pyqtSignal(str)
 
     def __init__(
-        self, connector: "MOTIONConnector", target: str, tag: str, verify: bool = False,
+        self, connector: "MotionConnector", target: str, tag: str, verify: bool = False,
         local_jed_path: str | None = None,
     ):
         super().__init__()
@@ -763,7 +763,7 @@ class CaptureThread(QThread):
         self.wait(500)
 
 
-class MOTIONConnector(QObject):
+class MotionConnector(QObject):
     # Ensure signals are correctly defined
     signalConnected = pyqtSignal(str, str)  # (descriptor, port)
     signalDisconnected = pyqtSignal(str, str)  # (descriptor, port)
@@ -1324,7 +1324,7 @@ class MOTIONConnector(QObject):
         self._runlog_active = True
 
         # --- Gather version info for header ---
-        # SDK version (MOTION SDK / sensor SDK)
+        # SDK version (Motion SDK / sensor SDK)
         try:
             sdk_ver = (
                 self._interface.get_sdk_version()
@@ -3515,7 +3515,7 @@ class MOTIONConnector(QObject):
 
     @pyqtSlot()
     def shutdown(self):
-        logger.info("Shutting down MOTIONConnector...")
+        logger.info("Shutting down MotionConnector...")
 
         if self._capture_thread:
             self._capture_thread.stop()
@@ -3529,7 +3529,7 @@ class MOTIONConnector(QObject):
 class ConsoleStatusThread(QThread):
     statusUpdate = pyqtSignal(str)
 
-    def __init__(self, connector: MOTIONConnector, parent=None):
+    def __init__(self, connector: MotionConnector, parent=None):
         super().__init__(parent)
         self.connector = connector
         self._running = True

--- a/pages/Console.qml
+++ b/pages/Console.qml
@@ -96,17 +96,17 @@ Rectangle {
 
     function updateStates() {
         // console.log("Console Updating all states...")
-        MOTIONInterface.queryConsoleInfo()
-        MOTIONInterface.queryRGBState() // Query Indicator state
-        MOTIONInterface.readFanFeedback() // One-shot fan PWM feedback read
-        MOTIONInterface.queryConsoleTemperature()
-        MOTIONInterface.queryTecTripValue();
+        MotionInterface.queryConsoleInfo()
+        MotionInterface.queryRGBState() // Query Indicator state
+        MotionInterface.readFanFeedback() // One-shot fan PWM feedback read
+        MotionInterface.queryConsoleTemperature()
+        MotionInterface.queryTecTripValue();
     }
 
 
     // Run refresh logic immediately on page load if Console is already connected
     Component.onCompleted: {
-        if (MOTIONInterface.consoleConnected) {
+        if (MotionInterface.consoleConnected) {
             // console.log("Page Loaded - Console Already Connected. Fetching Info...")
             updateStates()
         }
@@ -123,11 +123,11 @@ Rectangle {
     }
 
     Connections {
-        target: MOTIONInterface
+        target: MotionInterface
 
         // Handle Console Connected state
         function onConsoleConnectedChanged() {
-            if (MOTIONInterface.consoleConnected) {
+            if (MotionInterface.consoleConnected) {
                 infoTimer.start()          // One-time info fetch
             } else {
                 // console.log("Console Disconnected - Clearing Data...")
@@ -257,7 +257,7 @@ Rectangle {
                                 Layout.preferredWidth: 80
                                 Layout.preferredHeight: 40
                                 hoverEnabled: true  // Enable hover detection
-                                enabled: MOTIONInterface.consoleConnected 
+                                enabled: MotionInterface.consoleConnected 
 
                                 contentItem: Text {
                                     text: parent.text
@@ -284,7 +284,7 @@ Rectangle {
                                 }
 
                                 onClicked: {
-                                    if(MOTIONInterface.sendPingCommand("console")){                                        
+                                    if(MotionInterface.sendPingCommand("console")){                                        
                                         pingResult.text = "Ping SUCCESS"
                                         pingResult.color = "green"
                                     }else{
@@ -311,7 +311,7 @@ Rectangle {
                                 Layout.preferredWidth: 80
                                 Layout.preferredHeight: 40
                                 hoverEnabled: true  // Enable hover detection
-                                enabled: MOTIONInterface.consoleConnected 
+                                enabled: MotionInterface.consoleConnected 
 
                                 contentItem: Text {
                                     text: parent.text
@@ -338,7 +338,7 @@ Rectangle {
                                 }
 
                                 onClicked: {
-                                    if(MOTIONInterface.sendLedToggleCommand("console"))
+                                    if(MotionInterface.sendLedToggleCommand("console"))
                                     {
                                         toggleLedResult.text = "LED Toggled"
                                         toggleLedResult.color = "green"
@@ -364,7 +364,7 @@ Rectangle {
                                 Layout.preferredWidth: 80
                                 Layout.preferredHeight: 40
                                 hoverEnabled: true  // Enable hover detection
-                                enabled: MOTIONInterface.consoleConnected 
+                                enabled: MotionInterface.consoleConnected 
 
                                 contentItem: Text {
                                     text: parent.text
@@ -392,7 +392,7 @@ Rectangle {
 
                                 onClicked: {
 
-                                    if(MOTIONInterface.sendEchoCommand("console"))
+                                    if(MotionInterface.sendEchoCommand("console"))
                                     {
                                         echoResult.text = "Echo SUCCESS"
                                         echoResult.color = "green"
@@ -420,11 +420,11 @@ Rectangle {
                                 Layout.preferredWidth: 120
                                 Layout.preferredHeight: 28
                                 model: ["Off", "IND1", "IND2", "IND3"]
-                                enabled: MOTIONInterface.consoleConnected  
+                                enabled: MotionInterface.consoleConnected  
 
                                 onActivated: {
                                     let rgbValue = rgbLedDropdown.currentIndex  // Directly map ComboBox index to integer value
-                                    MOTIONInterface.setRGBState(rgbValue)         // Assuming you implement this new method
+                                    MotionInterface.setRGBState(rgbValue)         // Assuming you implement this new method
                                     rgbLedResult.text = rgbLedDropdown.currentText
                                 }
                             }
@@ -443,7 +443,7 @@ Rectangle {
                                 Layout.preferredWidth: 80
                                 Layout.preferredHeight: 40
                                 hoverEnabled: true  // Enable hover detection
-                                enabled: MOTIONInterface.consoleConnected 
+                                enabled: MotionInterface.consoleConnected 
 
                                 contentItem: Text {
                                     text: parent.text
@@ -470,7 +470,7 @@ Rectangle {
                                 }
 
                                 onClicked: {
-                                    var devices = MOTIONInterface.scanI2C(1, 0)
+                                    var devices = MotionInterface.scanI2C(1, 0)
                                     if (devices && devices.includes("0x20") && devices.includes("0x48")  && devices.includes("0x4b")) {
                                         pduResult.text = "PDU SUCCESS"
                                         pduResult.color = "green"
@@ -498,7 +498,7 @@ Rectangle {
                                 Layout.preferredWidth: 80
                                 Layout.preferredHeight: 40
                                 hoverEnabled: true  // Enable hover detection
-                                enabled: MOTIONInterface.consoleConnected 
+                                enabled: MotionInterface.consoleConnected 
 
                                 contentItem: Text {
                                     text: parent.text
@@ -525,7 +525,7 @@ Rectangle {
                                 }
 
                                 onClicked: {
-                                    var devices = MOTIONInterface.scanI2C(1, 5)
+                                    var devices = MotionInterface.scanI2C(1, 5)
                                     if (devices && devices.includes("0x41")) {
                                         seedResult.text = "Seed SUCCESS"
                                         seedResult.color = "green"
@@ -550,7 +550,7 @@ Rectangle {
                                 Layout.preferredWidth: 80
                                 Layout.preferredHeight: 40
                                 hoverEnabled: true  // Enable hover detection
-                                enabled: MOTIONInterface.consoleConnected 
+                                enabled: MotionInterface.consoleConnected 
 
                                 contentItem: Text {
                                     text: parent.text
@@ -577,7 +577,7 @@ Rectangle {
                                 }
 
                                 onClicked: {
-                                    var devices = MOTIONInterface.scanI2C(1, 4)
+                                    var devices = MotionInterface.scanI2C(1, 4)
                                     if (devices && devices.includes("0x41")) {
                                         taResult.text = "TA SUCCESS"
                                         taResult.color = "green"
@@ -605,7 +605,7 @@ Rectangle {
                                 Layout.preferredWidth: 80
                                 Layout.preferredHeight: 40
                                 hoverEnabled: true  // Enable hover detection
-                                enabled: MOTIONInterface.consoleConnected 
+                                enabled: MotionInterface.consoleConnected 
 
                                 contentItem: Text {
                                     text: parent.text
@@ -633,7 +633,7 @@ Rectangle {
 
                                 onClicked: {
                                     
-                                    var devices = MOTIONInterface.scanI2C(1, 6)
+                                    var devices = MotionInterface.scanI2C(1, 6)
                                     if (devices && devices.includes("0x41")) {
                                         safetyResult.text = "Safety EE SUCCESS"
                                         safetyResult.color = "green"
@@ -660,7 +660,7 @@ Rectangle {
                                 Layout.preferredWidth: 80
                                 Layout.preferredHeight: 40
                                 hoverEnabled: true  // Enable hover detection
-                                enabled: MOTIONInterface.consoleConnected 
+                                enabled: MotionInterface.consoleConnected 
 
                                 contentItem: Text {
                                     text: parent.text
@@ -687,7 +687,7 @@ Rectangle {
                                 }
 
                                 onClicked: {
-                                    if (MOTIONInterface.getTecEnabled()) {
+                                    if (MotionInterface.getTecEnabled()) {
                                         tecResult.text = "TEC SUCCESS"
                                         tecResult.color = "green"
                                     } else {
@@ -714,7 +714,7 @@ Rectangle {
                                 Layout.preferredWidth: 80
                                 Layout.preferredHeight: 40
                                 hoverEnabled: true  // Enable hover detection
-                                enabled: MOTIONInterface.consoleConnected 
+                                enabled: MotionInterface.consoleConnected 
 
                                 contentItem: Text {
                                     text: parent.text
@@ -742,7 +742,7 @@ Rectangle {
 
                                 onClicked: {
                                     
-                                    var devices = MOTIONInterface.scanI2C(1, 7)
+                                    var devices = MotionInterface.scanI2C(1, 7)
                                     if (devices && devices.includes("0x41")) {
                                         safety2Result.text = "Safety OPT SUCCESS"
                                         safety2Result.color = "green"
@@ -769,7 +769,7 @@ Rectangle {
                         color: "#1E1E20"
                         border.color: "#3E4E6F"
                         border.width: 2
-                        enabled: MOTIONInterface.consoleConnected
+                        enabled: MotionInterface.consoleConnected
 
                         // Title
                         Text {
@@ -799,7 +799,7 @@ Rectangle {
 
                                 ComboBox {
                                     id: fpgaSelector
-                                    model: MOTIONInterface.fpgaAddressModel
+                                    model: MotionInterface.fpgaAddressModel
                                     textRole: "label"
                                     Layout.fillWidth: true
                                     Layout.preferredHeight: 32
@@ -815,7 +815,7 @@ Rectangle {
                                     id: functionSelector
                                     Layout.fillWidth: true
                                     Layout.preferredHeight: 32
-                                    model: fpgaSelector.currentIndex >= 0 ? MOTIONInterface.fpgaAddressModel[fpgaSelector.currentIndex].functions : []
+                                    model: fpgaSelector.currentIndex >= 0 ? MotionInterface.fpgaAddressModel[fpgaSelector.currentIndex].functions : []
                                     textRole: "name"
                                     enabled: fpgaSelector.currentIndex >= 0
 
@@ -873,7 +873,7 @@ Rectangle {
                                     Layout.preferredWidth: 100
                                     Layout.preferredHeight: 40
                                     hoverEnabled: true
-                                    enabled: MOTIONInterface.consoleConnected && functionSelector.currentIndex >= 0 &&
+                                    enabled: MotionInterface.consoleConnected && functionSelector.currentIndex >= 0 &&
                                             (accessSelector.currentText === "Read" || (hexInput.acceptableInput && hexInput.text.length > 0))
 
                                     contentItem: Text {
@@ -890,7 +890,7 @@ Rectangle {
                                     }
 
                                     onClicked: {
-                                        const fpga = MOTIONInterface.fpgaAddressModel[fpgaSelector.currentIndex];
+                                        const fpga = MotionInterface.fpgaAddressModel[fpgaSelector.currentIndex];
                                         const i2cAddr = fpga.i2c_addr;
                                         const muxIdx = fpga.mux_idx;
                                         const channel = fpga.channel;
@@ -904,7 +904,7 @@ Rectangle {
 
                                         if (dir === "Read") {
                                             // console.log(`READ from ${fpga.label} @ 0x${offset.toString(16)}`);
-                                            let result = MOTIONInterface.i2cReadBytes("console", muxIdx, channel, i2cAddr, offset, length);
+                                            let result = MotionInterface.i2cReadBytes("console", muxIdx, channel, i2cAddr, offset, length);
 
                                             if (result.length === 0) {
                                                 console.error("Read failed or returned empty array.");
@@ -983,7 +983,7 @@ Rectangle {
 
                                             // console.log("Data to send:", dataToSend.map(b => "0x" + b.toString(16).padStart(2, "0")).join(" "));
 
-                                            let success = MOTIONInterface.i2cWriteBytes("console", muxIdx, channel, i2cAddr, offset, dataToSend);
+                                            let success = MotionInterface.i2cWriteBytes("console", muxIdx, channel, i2cAddr, offset, dataToSend);
 
                                             if (success) {
                                                 // console.log("Write successful.");
@@ -1078,7 +1078,7 @@ Rectangle {
                                     to: 100
                                     stepSize: 10
                                     value: fan_speed || 0
-                                    enabled: MOTIONInterface.consoleConnected
+                                    enabled: MotionInterface.consoleConnected
 
                                     property bool userIsSliding: false
 
@@ -1089,7 +1089,7 @@ Rectangle {
                                             let snappedValue = Math.round(value / 10) * 10
                                             value = snappedValue
                                             userIsSliding = false
-                                            let success = MOTIONInterface.setFanLevel(snappedValue)
+                                            let success = MotionInterface.setFanLevel(snappedValue)
                                             if (!success) console.error("Failed to set fan speed")
                                         }
                                     }
@@ -1110,11 +1110,11 @@ Rectangle {
 
                                 Button {
                                     text: "Get Fan Feedback"
-                                    enabled: MOTIONInterface.consoleConnected
+                                    enabled: MotionInterface.consoleConnected
                                     width: 280
                                     height: 32
                                     font.pixelSize: 12
-                                    onClicked: MOTIONInterface.readFanFeedback()
+                                    onClicked: MotionInterface.readFanFeedback()
                                 }
                             }
                         }
@@ -1128,7 +1128,7 @@ Rectangle {
                             color: "#1E1E20"
                             border.color: "#3E4E6F"
                             border.width: 2
-                            enabled: MOTIONInterface.consoleConnected
+                            enabled: MotionInterface.consoleConnected
 
                             // Title
                             Text {
@@ -1174,7 +1174,7 @@ Rectangle {
                                         placeholderText: "0-125"
                                         validator: taIntVal
                                         inputMethodHints: Qt.ImhDigitsOnly
-                                        text: MOTIONInterface.tecTripValue.toString()
+                                        text: MotionInterface.tecTripValue.toString()
 
                                         onAccepted: {
                                             // Clamp and normalize
@@ -1185,7 +1185,7 @@ Rectangle {
                                                 if (v < 0) v = 0
                                                 if (v > 125) v = 125
                                                 text = v.toString()
-                                                let ok = MOTIONInterface.setTecTrip(v)
+                                                let ok = MotionInterface.setTecTrip(v)
                                                 if (!ok) {
                                                   
                                                 }
@@ -1201,12 +1201,12 @@ Rectangle {
                                             onTriggered: tecTripInput.tecTripSetError = ""
                                         }
                                         Connections {
-                                            target: MOTIONInterface
+                                            target: MotionInterface
                                             function onTecTripValueChanged() {
-                                                tecTripInput.text = MOTIONInterface.tecTripValue.toString()
+                                                tecTripInput.text = MotionInterface.tecTripValue.toString()
                                             }
                                             function onTaGainSetFailed(msg) {
-                                                tecTripInput.text = MOTIONInterface.tecTripValue.toString()
+                                                tecTripInput.text = MotionInterface.tecTripValue.toString()
                                                 tecTripInput.tecTripSetError = msg
                                                 tecTripSetErrorTimer.restart()
                                             }
@@ -1259,13 +1259,13 @@ Rectangle {
                                 width: 20
                                 height: 20
                                 radius: 10
-                                color: MOTIONInterface.consoleConnected ? "green" : "red"
+                                color: MotionInterface.consoleConnected ? "green" : "red"
                                 border.color: "black"
                                 border.width: 1
                             }
 
                             Text {
-                                text: MOTIONInterface.consoleConnected ? "Connected" : "Not Connected"
+                                text: MotionInterface.consoleConnected ? "Connected" : "Not Connected"
                                 font.pixelSize: 16
                                 color: "#BDC3C7"
                             }
@@ -1283,7 +1283,7 @@ Rectangle {
                                 radius: 15
                                 color: enabled ? "#2C3E50" : "#7F8C8D"  // Dim when disabled
                                 Layout.alignment: Qt.AlignRight  
-                                enabled: MOTIONInterface.consoleConnected
+                                enabled: MotionInterface.consoleConnected
 
                                 // Icon Text
                                 Text {
@@ -1372,7 +1372,7 @@ Rectangle {
                             height: 40
                             radius: 10
                             color: enabled ? "#E74C3C" : "#7F8C8D"  // Red when enabled, gray when disabled
-                            enabled: MOTIONInterface.consoleConnected
+                            enabled: MotionInterface.consoleConnected
 
                             Text {
                                 text: "Soft Reset"
@@ -1387,7 +1387,7 @@ Rectangle {
                                 enabled: parent.enabled  // Disable MouseArea when the button is disabled
                                 onClicked: {
                                     // console.log("Soft Reset Triggered")
-                                    MOTIONInterface.softResetSensor("console")
+                                    MotionInterface.softResetSensor("console")
                                 }
 
                                 onEntered: {

--- a/pages/Demo.qml
+++ b/pages/Demo.qml
@@ -25,7 +25,7 @@ Rectangle {
 
     // Show loading overlay whenever this page becomes visible while connected
     onVisibleChanged: {
-        if (visible && MOTIONInterface.consoleConnected) {
+        if (visible && MotionInterface.consoleConnected) {
             demoLoading = true
             consoleUpdateTimer.restart()
         }
@@ -33,9 +33,9 @@ Rectangle {
     
     // Track PDC min/max whenever the value changes
     Connections {
-        target: MOTIONInterface
+        target: MotionInterface
         function onPdcChanged() {
-            var v = MOTIONInterface.pdc;
+            var v = MotionInterface.pdc;
             if (isNaN(page1.pdcMin) || v < page1.pdcMin) page1.pdcMin = v;
             if (isNaN(page1.pdcMax) || v > page1.pdcMax) page1.pdcMax = v;
         }
@@ -97,7 +97,7 @@ Rectangle {
 
     function writeFpgaRegister(fpgaLabel, funcName, data) {
 
-        const fModel = MOTIONInterface.fpgaAddressModel.find(fpga => fpga.label === fpgaLabel);
+        const fModel = MotionInterface.fpgaAddressModel.find(fpga => fpga.label === fpgaLabel);
 
         if (!fModel) {
             console.error("FPGA Label not found");
@@ -127,7 +127,7 @@ Rectangle {
                 console.warn("Invalid numeric input for unit conversion.");
                 return;
             }
-            fullValue = Math.round(floatVal / MOTIONInterface.getScale(fpgaLabel, funcName));
+            fullValue = Math.round(floatVal / MotionInterface.getScale(fpgaLabel, funcName));
         } else {
             let sanitized = data.replace(/0x/gi, "").replace(/\s+/g, "");
 
@@ -157,7 +157,7 @@ Rectangle {
 
         // console.log("Data to send:", dataToSend.map(b => "0x" + b.toString(16).padStart(2, "0")).join(" "));
 
-        let success = MOTIONInterface.i2cWriteBytes("console", muxIdx, channel, i2cAddr, offset, dataToSend);
+        let success = MotionInterface.i2cWriteBytes("console", muxIdx, channel, i2cAddr, offset, dataToSend);
 
         if (success) {
             // console.log("Write successful.");
@@ -172,7 +172,7 @@ Rectangle {
 
     function readFpgaRegister(fpgaLabel, funcName, field) {
         
-        const fModel = MOTIONInterface.fpgaAddressModel.find(fpga => fpga.label === fpgaLabel);
+        const fModel = MotionInterface.fpgaAddressModel.find(fpga => fpga.label === fpgaLabel);
 
         if (!fModel) {
             console.error("FPGA Label not found");
@@ -195,7 +195,7 @@ Rectangle {
         const data_len = parseInt(myFn.data_size.replace("B", "")) / 8;
 
         // console.log(`READ from ${fModel.label} @ 0x${offset.toString(16)}`);
-        let result = MOTIONInterface.i2cReadBytes("console", muxIdx, channel, i2cAddr, offset, data_len);
+        let result = MotionInterface.i2cReadBytes("console", muxIdx, channel, i2cAddr, offset, data_len);
 
         if (result.length === 0) {
             // console.log("Read failed or returned empty array.");
@@ -220,7 +220,7 @@ Rectangle {
             let rawValue = fullValue;  // store globally
 
             if (myFn.unit && myFn.scale) {
-                field.text = (fullValue * MOTIONInterface.getScale(fpgaLabel, funcName)).toFixed(3);
+                field.text = (fullValue * MotionInterface.getScale(fpgaLabel, funcName)).toFixed(3);
             } else {
                 let hexStr = "0x" + fullValue.toString(16).toUpperCase().padStart(length * 2, "0");
                 field.text = hexStr;
@@ -271,9 +271,9 @@ Rectangle {
 
     // Ensure laser power config is loaded once when console connects.
     Connections {
-        target: MOTIONInterface
+        target: MotionInterface
         function onConsoleConnectedChanged() {
-            if (!MOTIONInterface.consoleConnected) {
+            if (!MotionInterface.consoleConnected) {
                 powerConfigLoaded = false;
             }
         }
@@ -281,7 +281,7 @@ Rectangle {
 
     // HEADER
     Text {
-        text: "MOTION Blood Flow Demo"
+        text: "Open-Motion Blood Flow Demo"
         font.pixelSize: 20
         font.weight: Font.Bold
         color: "white"
@@ -314,7 +314,7 @@ Rectangle {
                 radius: 10
                 border.color: "#3E4E6F"
                 border.width: 2
-                enabled: MOTIONInterface.consoleConnected
+                enabled: MotionInterface.consoleConnected
 
                 ColumnLayout {
                     anchors.fill: parent
@@ -346,7 +346,7 @@ Rectangle {
                                     id: taDrive
                                     Layout.preferredWidth: 100
                                     Layout.preferredHeight: 30
-                                    enabled: MOTIONInterface.consoleConnected
+                                    enabled: MotionInterface.consoleConnected
                                     font.pixelSize: 12
                                     validator: IntValidator { bottom: 0; top: 10000 }
                                     background: Rectangle {
@@ -375,7 +375,7 @@ Rectangle {
                                     id: taPulseWidth
                                     Layout.preferredWidth: 100
                                     Layout.preferredHeight: 30
-                                    enabled: MOTIONInterface.consoleConnected
+                                    enabled: MotionInterface.consoleConnected
                                     font.pixelSize: 12
                                     validator: IntValidator { bottom: 0; top: 5000000 }
                                     background: Rectangle {
@@ -392,7 +392,7 @@ Rectangle {
                                 Layout.preferredWidth: 100
                                 Layout.preferredHeight: 40
                                 hoverEnabled: true
-                                enabled: MOTIONInterface.consoleConnected
+                                enabled: MotionInterface.consoleConnected
 
                                 contentItem: Text {
                                     text: parent.text
@@ -452,7 +452,7 @@ Rectangle {
                                     id: ddsCurrent
                                     Layout.preferredWidth: 100
                                     Layout.preferredHeight: 30
-                                    enabled: MOTIONInterface.consoleConnected
+                                    enabled: MotionInterface.consoleConnected
                                     font.pixelSize: 12
                                     validator: IntValidator { bottom: 0; top: 4100 }
                                     background: Rectangle {
@@ -476,7 +476,7 @@ Rectangle {
                                     id: ddsCurrentLimit
                                     Layout.preferredWidth: 100
                                     Layout.preferredHeight: 30
-                                    enabled: MOTIONInterface.consoleConnected
+                                    enabled: MotionInterface.consoleConnected
                                     font.pixelSize: 12
                                     validator: IntValidator { bottom: 0; top: 1200 }
                                     background: Rectangle {
@@ -504,7 +504,7 @@ Rectangle {
                                     id: cwSeedCurrent
                                     Layout.preferredWidth: 100
                                     Layout.preferredHeight: 30
-                                    enabled: MOTIONInterface.consoleConnected
+                                    enabled: MotionInterface.consoleConnected
                                     font.pixelSize: 12
                                     validator: IntValidator { bottom: 0; top: 4100 }
                                     background: Rectangle {
@@ -528,7 +528,7 @@ Rectangle {
                                     id: cwSeedCurrentLimit
                                     Layout.preferredWidth: 100
                                     Layout.preferredHeight: 30
-                                    enabled: MOTIONInterface.consoleConnected
+                                    enabled: MotionInterface.consoleConnected
                                     font.pixelSize: 12
                                     validator: IntValidator { bottom: 0; top: 1200 }
                                     background: Rectangle {
@@ -543,7 +543,7 @@ Rectangle {
                                 Layout.preferredWidth: 100
                                 Layout.preferredHeight: 40
                                 hoverEnabled: true
-                                enabled: MOTIONInterface.consoleConnected 
+                                enabled: MotionInterface.consoleConnected 
 
                                 contentItem: Text {
                                     text: parent.text
@@ -620,7 +620,7 @@ Rectangle {
                                         id: pwLowerLimit
                                         Layout.preferredWidth: 100
                                         Layout.preferredHeight: 30
-                                        enabled: MOTIONInterface.consoleConnected
+                                        enabled: MotionInterface.consoleConnected
                                         font.pixelSize: 12
                                         validator: IntValidator { bottom: 0; top: 1000000 }
                                         background: Rectangle {
@@ -644,7 +644,7 @@ Rectangle {
                                         id: pwUpperLimit
                                         Layout.preferredWidth: 100
                                         Layout.preferredHeight: 30
-                                        enabled: MOTIONInterface.consoleConnected
+                                        enabled: MotionInterface.consoleConnected
                                         font.pixelSize: 12
                                         validator: IntValidator { bottom: 0; top: 1000000 }
                                         background: Rectangle {
@@ -672,7 +672,7 @@ Rectangle {
                                         id: periodLowerLimit
                                         Layout.preferredWidth: 100
                                         Layout.preferredHeight: 30
-                                        enabled: MOTIONInterface.consoleConnected
+                                        enabled: MotionInterface.consoleConnected
                                         font.pixelSize: 12
                                         validator: IntValidator { bottom: 0; top: 1000000 }
                                         background: Rectangle {
@@ -701,7 +701,7 @@ Rectangle {
                                         id: driveCurrentLimit
                                         Layout.preferredWidth: 100
                                         Layout.preferredHeight: 30
-                                        enabled: MOTIONInterface.consoleConnected
+                                        enabled: MotionInterface.consoleConnected
                                         font.pixelSize: 12
                                         validator: IntValidator { bottom: 0; top: 32000 }
                                         background: Rectangle {
@@ -716,7 +716,7 @@ Rectangle {
                                     Layout.preferredWidth: 100
                                     Layout.preferredHeight: 40
                                     hoverEnabled: true
-                                    enabled: MOTIONInterface.consoleConnected 
+                                    enabled: MotionInterface.consoleConnected 
 
                                     contentItem: Text {
                                         text: parent.text
@@ -745,7 +745,7 @@ Rectangle {
                                         // console.log("Clear Safety Error Flag");
 
                                         writeFpgaRegister("Safety OPT", "DYNAMIC CTRL", "2");
-                                        MOTIONInterface.readSafetyStatus();
+                                        MotionInterface.readSafetyStatus();
                                     }
                                 }
 
@@ -768,7 +768,7 @@ Rectangle {
                                         id: cwSafetyCurrentLimit
                                         Layout.preferredWidth: 100
                                         Layout.preferredHeight: 30
-                                        enabled: MOTIONInterface.consoleConnected
+                                        enabled: MotionInterface.consoleConnected
                                         font.pixelSize: 12
                                         validator: IntValidator { bottom: 0; top: 32000 }
                                         background: Rectangle {
@@ -784,7 +784,7 @@ Rectangle {
                                     Layout.preferredWidth: 100
                                     Layout.preferredHeight: 40
                                     hoverEnabled: true
-                                    enabled: MOTIONInterface.consoleConnected 
+                                    enabled: MotionInterface.consoleConnected 
 
                                     contentItem: Text {
                                         text: parent.text
@@ -814,7 +814,7 @@ Rectangle {
 
                                         writeFpgaRegister("Safety OPT", "DYNAMIC CTRL", "1");
                                         writeFpgaRegister("Safety EE", "DYNAMIC CTRL", "1");
-                                        MOTIONInterface.readSafetyStatus();
+                                        MotionInterface.readSafetyStatus();
                                     }
                                 }
 
@@ -837,7 +837,7 @@ Rectangle {
                                         id: pwmCurrentLimit
                                         Layout.preferredWidth: 100
                                         Layout.preferredHeight: 30
-                                        enabled: MOTIONInterface.consoleConnected
+                                        enabled: MotionInterface.consoleConnected
                                         font.pixelSize: 12
                                         validator: IntValidator { bottom: 0; top: 1000 }
                                         background: Rectangle {
@@ -852,7 +852,7 @@ Rectangle {
                                     Layout.preferredWidth: 100
                                     Layout.preferredHeight: 40
                                     hoverEnabled: true
-                                    enabled: MOTIONInterface.consoleConnected 
+                                    enabled: MotionInterface.consoleConnected 
 
                                     contentItem: Text {
                                         text: parent.text
@@ -916,7 +916,7 @@ Rectangle {
                                         id: pw2LowerLimit
                                         Layout.preferredWidth: 100
                                         Layout.preferredHeight: 30
-                                        enabled: MOTIONInterface.consoleConnected
+                                        enabled: MotionInterface.consoleConnected
                                         font.pixelSize: 12
                                         validator: IntValidator { bottom: 0; top: 1000000 }
                                         background: Rectangle {
@@ -940,7 +940,7 @@ Rectangle {
                                         id: pw2UpperLimit
                                         Layout.preferredWidth: 100
                                         Layout.preferredHeight: 30
-                                        enabled: MOTIONInterface.consoleConnected
+                                        enabled: MotionInterface.consoleConnected
                                         font.pixelSize: 12
                                         validator: IntValidator { bottom: 0; top: 1000000 }
                                         background: Rectangle {
@@ -968,7 +968,7 @@ Rectangle {
                                         id: period2LowerLimit
                                         Layout.preferredWidth: 100
                                         Layout.preferredHeight: 30
-                                        enabled: MOTIONInterface.consoleConnected
+                                        enabled: MotionInterface.consoleConnected
                                         font.pixelSize: 12
                                         validator: IntValidator { bottom: 0; top: 1000000 }
                                         background: Rectangle {
@@ -997,7 +997,7 @@ Rectangle {
                                         id: drive2CurrentLimit
                                         Layout.preferredWidth: 100
                                         Layout.preferredHeight: 30
-                                        enabled: MOTIONInterface.consoleConnected
+                                        enabled: MotionInterface.consoleConnected
                                         font.pixelSize: 12
                                         validator: IntValidator { bottom: 0; top: 1000 }
                                         background: Rectangle {
@@ -1026,7 +1026,7 @@ Rectangle {
                                         id: cw2SafetyCurrentLimit
                                         Layout.preferredWidth: 100
                                         Layout.preferredHeight: 30
-                                        enabled: MOTIONInterface.consoleConnected
+                                        enabled: MotionInterface.consoleConnected
                                         font.pixelSize: 12
                                         validator: IntValidator { bottom: 0; top: 1000 }
                                         background: Rectangle {
@@ -1041,7 +1041,7 @@ Rectangle {
                                     Layout.preferredWidth: 100
                                     Layout.preferredHeight: 40
                                     hoverEnabled: true
-                                    enabled: MOTIONInterface.consoleConnected 
+                                    enabled: MotionInterface.consoleConnected 
 
                                     contentItem: Text {
                                         text: parent.text
@@ -1071,7 +1071,7 @@ Rectangle {
 
                                         writeFpgaRegister("Safety OPT", "DYNAMIC CTRL", "1");
                                         writeFpgaRegister("Safety EE", "DYNAMIC CTRL", "1");
-                                        MOTIONInterface.readSafetyStatus();
+                                        MotionInterface.readSafetyStatus();
                                     }
                                 }
                                 
@@ -1094,7 +1094,7 @@ Rectangle {
                                         id: pwm2CurrentLimit
                                         Layout.preferredWidth: 100
                                         Layout.preferredHeight: 30
-                                        enabled: MOTIONInterface.consoleConnected
+                                        enabled: MotionInterface.consoleConnected
                                         font.pixelSize: 12
                                         validator: IntValidator { bottom: 0; top: 1000 }
                                         background: Rectangle {
@@ -1109,7 +1109,7 @@ Rectangle {
                                     Layout.preferredWidth: 100
                                     Layout.preferredHeight: 40
                                     hoverEnabled: true
-                                    enabled: MOTIONInterface.consoleConnected 
+                                    enabled: MotionInterface.consoleConnected 
 
                                     contentItem: Text {
                                         text: parent.text
@@ -1155,7 +1155,7 @@ Rectangle {
                             // Fallback: if you don’t have safetyStack, do an initial refresh when created
                             Component.onCompleted: {
                                 try{
-                                    MOTIONInterface.tec_status();
+                                    MotionInterface.tec_status();
                                 }catch(e){
                                     console.error(e);
                                 }
@@ -1200,7 +1200,7 @@ Rectangle {
                                             Text { text: "Setpoint (°C)"; color: "#BDC3C7"; font.pixelSize: 11 }
                                             Text {
                                                 // Bind to your live value:
-                                                text: Number(MOTIONInterface.tecTemp || 0).toFixed(3)
+                                                text: Number(MotionInterface.tecTemp || 0).toFixed(3)
                                                 color: "white"
                                                 font.pixelSize: 14
                                             }
@@ -1223,7 +1223,7 @@ Rectangle {
                                             Text { text: "Current (I)"; color: "#BDC3C7"; font.pixelSize: 11 }
                                             Text {
                                                 // Bind to your live value:
-                                                text: Number(MOTIONInterface.tecMonC || 0).toFixed(3)
+                                                text: Number(MotionInterface.tecMonC || 0).toFixed(3)
                                                 color: "white"
                                                 font.pixelSize: 14
                                             }
@@ -1246,7 +1246,7 @@ Rectangle {
                                             Text { text: "Voltage (V)"; color: "#BDC3C7"; font.pixelSize: 11 }
                                             Text {
                                                 // Bind to your live value:
-                                                text: Number(MOTIONInterface.tecMonV|| 0).toFixed(3)
+                                                text: Number(MotionInterface.tecMonV|| 0).toFixed(3)
                                                 color: "white"
                                                 font.pixelSize: 14
                                             }
@@ -1272,7 +1272,7 @@ Rectangle {
 
                                         Rectangle {
                                             width: 20; height: 20; radius: 10
-                                            color: MOTIONInterface.tecGood ? "green" : "red"
+                                            color: MotionInterface.tecGood ? "green" : "red"
                                             border.color: "black"; border.width: 1
                                             Layout.alignment: Qt.AlignHCenter                                            
                                         }
@@ -1317,9 +1317,9 @@ Rectangle {
                                             Layout.minimumWidth: 80
                                             Layout.maximumWidth: 80
                                             Layout.preferredHeight: 30
-                                            enabled: MOTIONInterface.consoleConnected
+                                            enabled: MotionInterface.consoleConnected
                                             font.pixelSize: 12
-                                            text: MOTIONInterface.tecDAC.toFixed(3)
+                                            text: MotionInterface.tecDAC.toFixed(3)
 
                                             // UI-level guard: only allow -2.50–2.50 volts
                                             validator: DoubleValidator {
@@ -1348,7 +1348,7 @@ Rectangle {
                                             Layout.alignment: Qt.AlignRight
                                             Layout.rightMargin: 30  
                                             Layout.preferredWidth: 100
-                                            enabled: MOTIONInterface.consoleConnected
+                                            enabled: MotionInterface.consoleConnected
                                             onTriggered: {
                                                 const val = parseFloat(tecSetpoint.text)
                                                 if (isNaN(val) || val < -2.5 || val > 2.5) {
@@ -1356,11 +1356,11 @@ Rectangle {
                                                     return
                                                 }
                                     
-                                                if(!MOTIONInterface.tec_voltage(val)){
+                                                if(!MotionInterface.tec_voltage(val)){
                                                     console.error("Failed to write TEC DAC");
                                                 }
                                     
-                                                if(!MOTIONInterface.tec_status()){
+                                                if(!MotionInterface.tec_status()){
                                                     console.error("Failed to read status");
                                                 }
 
@@ -1473,8 +1473,8 @@ Rectangle {
                             textRole: "label"
                             Layout.preferredWidth: 140
                             Layout.preferredHeight: 32
-                            enabled: (sensorSelector.currentIndex === 0 && MOTIONInterface.leftSensorConnected) ||
-                                        (sensorSelector.currentIndex === 1 && MOTIONInterface.rightSensorConnected)
+                            enabled: (sensorSelector.currentIndex === 0 && MotionInterface.leftSensorConnected) ||
+                                        (sensorSelector.currentIndex === 1 && MotionInterface.rightSensorConnected)
 
                             onCurrentIndexChanged: {
                                 updatePatternOptions()
@@ -1487,8 +1487,8 @@ Rectangle {
                             textRole: "label"
                             Layout.preferredWidth: 120
                             Layout.preferredHeight: 32
-                            enabled: (sensorSelector.currentIndex === 0 && MOTIONInterface.leftSensorConnected) ||
-                                        (sensorSelector.currentIndex === 1 && MOTIONInterface.rightSensorConnected)
+                            enabled: (sensorSelector.currentIndex === 0 && MotionInterface.leftSensorConnected) ||
+                                        (sensorSelector.currentIndex === 1 && MotionInterface.rightSensorConnected)
 
                             onCurrentIndexChanged: {
                                 
@@ -1499,13 +1499,13 @@ Rectangle {
                             id: idCameraCapButton
                             text: {
                                 let mode = filteredPatternModel.get(patternSelector.currentIndex)
-                                return (mode && mode.label === "Stream") ? (MOTIONInterface.isStreaming ? "Stop" : "Start") : "Capture"
+                                return (mode && mode.label === "Stream") ? (MotionInterface.isStreaming ? "Stop" : "Start") : "Capture"
                             }
                             Layout.preferredWidth: 100
                             Layout.preferredHeight: 45
                             hoverEnabled: true  // Enable hover detection
-                            enabled: (sensorSelector.currentIndex === 0 && MOTIONInterface.leftSensorConnected) ||
-                                        (sensorSelector.currentIndex === 1 && MOTIONInterface.rightSensorConnected)
+                            enabled: (sensorSelector.currentIndex === 0 && MotionInterface.leftSensorConnected) ||
+                                        (sensorSelector.currentIndex === 1 && MotionInterface.rightSensorConnected)
 
                             contentItem: Text {
                                 text: parent.text
@@ -1538,12 +1538,12 @@ Rectangle {
                                 // console.log("Selected: ", target)
 
                                 if (tp && tp.label === "Stream") {
-                                    if (MOTIONInterface.isStreaming) {
-                                        // MOTIONInterface.stopCameraStream(cam.cam_num)
+                                    if (MotionInterface.isStreaming) {
+                                        // MotionInterface.stopCameraStream(cam.cam_num)
                                         // cameraCapStatus.text = "Stopped"
                                         // cameraCapStatus.color = "red"
                                     } else {
-                                        // MOTIONInterface.startCameraStream(cam.cam_num)
+                                        // MotionInterface.startCameraStream(cam.cam_num)
                                         // cameraCapStatus.text = "Streaming"
                                         // cameraCapStatus.color = "lightgreen"
                                     }
@@ -1555,7 +1555,7 @@ Rectangle {
                                         cameraCapStatus.color = "orange"
                                     })
 
-                                    MOTIONInterface.getCameraHistogram(target, cam.cam_num, tp.tp_id)
+                                    MotionInterface.getCameraHistogram(target, cam.cam_num, tp.tp_id)
                                 }
                             }
                         }
@@ -1585,7 +1585,7 @@ Rectangle {
                 radius: 10
                 border.color: "#3E4E6F"
                 border.width: 2
-                enabled: MOTIONInterface.consoleConnected
+                enabled: MotionInterface.consoleConnected
 
                 ColumnLayout {
                     anchors.fill: parent
@@ -1618,7 +1618,7 @@ Rectangle {
                                     id: fsFrequency
                                     Layout.preferredWidth: 100
                                     Layout.preferredHeight: 32
-                                    enabled: MOTIONInterface.consoleConnected
+                                    enabled: MotionInterface.consoleConnected
                                     font.pixelSize: 12
                                     text: "40.00"
                                     validator: DoubleValidator { bottom: 1.0; top: 100.0; decimals: 2; notation: DoubleValidator.StandardNotation }
@@ -1651,7 +1651,7 @@ Rectangle {
                                     Layout.preferredWidth: 100
                                     Layout.preferredHeight: 32
                                     text: "5000"
-                                    enabled: MOTIONInterface.consoleConnected
+                                    enabled: MotionInterface.consoleConnected
                                     font.pixelSize: 12
                                     validator: IntValidator { bottom: 1; top: 1000 }
                                     background: Rectangle {
@@ -1677,7 +1677,7 @@ Rectangle {
                                     Layout.preferredWidth: 100
                                     Layout.preferredHeight: 32
                                     text: "250"
-                                    enabled: MOTIONInterface.consoleConnected
+                                    enabled: MotionInterface.consoleConnected
                                     font.pixelSize: 12
                                     validator: IntValidator { bottom: 0; top: 1000 }
                                     background: Rectangle {
@@ -1703,7 +1703,7 @@ Rectangle {
                                     Layout.preferredWidth: 100
                                     Layout.preferredHeight: 32
                                     text: "5000"
-                                    enabled: MOTIONInterface.consoleConnected
+                                    enabled: MotionInterface.consoleConnected
                                     font.pixelSize: 12
                                     validator: IntValidator { bottom: 0; top: 1000 }
                                     background: Rectangle {
@@ -1717,7 +1717,7 @@ Rectangle {
                                 text: "Start Trigger"
                                 Layout.preferredWidth: 100
                                 Layout.preferredHeight: 34
-                                enabled: MOTIONInterface.consoleConnected
+                                enabled: MotionInterface.consoleConnected
                                 contentItem: Text {
                                     text: parent.text
                                     color: parent.enabled ? "#BDC3C7" : "#7F8C8D"
@@ -1753,7 +1753,7 @@ Rectangle {
                                         "EnableTaTrigger": true
                                     }
                                     var jsonString = JSON.stringify(json_trigger_data);
-                                    if (!MOTIONInterface.startTrigger(jsonString)) {
+                                    if (!MotionInterface.startTrigger(jsonString)) {
                                         console.error("Failed to apply and start trigger config")
                                     }
                                 }
@@ -1764,7 +1764,7 @@ Rectangle {
                                 text: "Stop Trigger"
                                 Layout.preferredWidth: 100
                                 Layout.preferredHeight: 34
-                                enabled: MOTIONInterface.consoleConnected
+                                enabled: MotionInterface.consoleConnected
                                 contentItem: Text {
                                     text: parent.text
                                     color: parent.enabled ? "#BDC3C7" : "#7F8C8D"
@@ -1786,7 +1786,7 @@ Rectangle {
                                     }
                                     radius: 4
                                 }
-                                onClicked: MOTIONInterface.stopTrigger()
+                                onClicked: MotionInterface.stopTrigger()
                             }
 
                             // Sync Out Checkbox
@@ -1794,7 +1794,7 @@ Rectangle {
                                 id: enableSyncOutCheckbox
                                 text: "Sync Out"
                                 checked: false
-                                enabled: MOTIONInterface.consoleConnected
+                                enabled: MotionInterface.consoleConnected
                                 Layout.preferredHeight: 34
                                 
                                 contentItem: Text {
@@ -1809,7 +1809,7 @@ Rectangle {
                             // Status Label aligned right
                             Text {
                                 id: triggerStatus
-                                text: MOTIONInterface.triggerState
+                                text: MotionInterface.triggerState
                                 color: triggerStatus.text === "ON" ? "lightgreen" : "red"
                                 font.pixelSize: 14
                                 Layout.columnSpan: 1
@@ -1844,7 +1844,7 @@ Rectangle {
                         Layout.alignment: Qt.AlignVCenter | Qt.AlignLeft
 
                         Text {
-                            text: "TCM: " + MOTIONInterface.tcm + " "
+                            text: "TCM: " + MotionInterface.tcm + " "
                             font.pixelSize: 14
                             color: "#BDC3C7"
                             ToolTip.text: "TCM (Trigger Count MCU) - Laser Pulse"
@@ -1860,7 +1860,7 @@ Rectangle {
                                         
                         }
                         Text {
-                            text: "TCL: " + MOTIONInterface.tcl + " "
+                            text: "TCL: " + MotionInterface.tcl + " "
                             font.pixelSize: 14
                             color: "#BDC3C7"
                             ToolTip.text: "TCL (Trigger Count FPGA) - Laser Pulse"
@@ -1875,12 +1875,12 @@ Rectangle {
                             }
                         }
                         Text {
-                            text: "PDC: " + (isNaN(MOTIONInterface.pdc) ? "--" : Math.round(MOTIONInterface.pdc)) + " mA"
+                            text: "PDC: " + (isNaN(MotionInterface.pdc) ? "--" : Math.round(MotionInterface.pdc)) + " mA"
                             font.pixelSize: 14
                             color: "#BDC3C7"
                             ToolTip.text: "PDC (Power Draw Current)\n" +
                                           "Min: " + (isNaN(page1.pdcMin) ? "--" : (Math.round(page1.pdcMin) + " mA (" + ("0x" + Math.round(page1.pdcMin).toString(16).toUpperCase()) + ")")) + "\n" +
-                                          "Cur: " + (isNaN(MOTIONInterface.pdc) ? "--" : (Math.round(MOTIONInterface.pdc) + " mA (" + ("0x" + Math.round(MOTIONInterface.pdc).toString(16).toUpperCase()) + ")")) + "\n" +
+                                          "Cur: " + (isNaN(MotionInterface.pdc) ? "--" : (Math.round(MotionInterface.pdc) + " mA (" + ("0x" + Math.round(MotionInterface.pdc).toString(16).toUpperCase()) + ")")) + "\n" +
                                           "Max: " + (isNaN(page1.pdcMax) ? "--" : (Math.round(page1.pdcMax) + " mA (" + ("0x" + Math.round(page1.pdcMax).toString(16).toUpperCase()) + ")"))
                             ToolTip.visible: maPdc.containsMouse
                             ToolTip.delay: 500
@@ -1906,7 +1906,7 @@ Rectangle {
                         
                         // Laser Temp (LT) - shows measured TEC voltage
                         Text {
-                            text: "LT: " + Number(MOTIONInterface.tecVoltage || 0).toFixed(2) + " °C"
+                            text: "LT: " + Number(MotionInterface.tecVoltage || 0).toFixed(2) + " °C"
                             font.pixelSize: 14
                             color: "#BDC3C7"
                             ToolTip.text: "Laser Temp"
@@ -1923,7 +1923,7 @@ Rectangle {
 
                         // Laser Set Temp (LST) - shows TEC setpoint temperature/value
                         Text {
-                            text: "LST: " + Number(MOTIONInterface.tecTemp || 0).toFixed(2) + " °C"
+                            text: "LST: " + Number(MotionInterface.tecTemp || 0).toFixed(2) + " °C"
                             font.pixelSize: 14
                             color: "#BDC3C7"
                             ToolTip.text: "Laser Set Temp"
@@ -1948,10 +1948,10 @@ Rectangle {
 
                         Text {
                             id: statusText
-                            text: "System State: " + (MOTIONInterface.state === 0 ? "Disconnected"
-                                            : MOTIONInterface.state === 1 ? "Sensor Connected"
-                                            : MOTIONInterface.state === 2 ? "Console Connected"
-                                            : MOTIONInterface.state === 3 ? "Ready"
+                            text: "System State: " + (MotionInterface.state === 0 ? "Disconnected"
+                                            : MotionInterface.state === 1 ? "Sensor Connected"
+                                            : MotionInterface.state === 2 ? "Console Connected"
+                                            : MotionInterface.state === 3 ? "Ready"
                                             : "Running")
                             font.pixelSize: 16
                             color: "#BDC3C7"
@@ -2002,13 +2002,13 @@ Rectangle {
 
                                     Rectangle {
                                         width: 20; height: 20; radius: 10
-                                        color: MOTIONInterface.leftSensorConnected ? "green" : "red"
+                                        color: MotionInterface.leftSensorConnected ? "green" : "red"
                                         border.color: "black"; border.width: 1
                                     }
 
                                     Rectangle {
                                         width: 20; height: 20; radius: 10
-                                        color: MOTIONInterface.rightSensorConnected ? "green" : "red"
+                                        color: MotionInterface.rightSensorConnected ? "green" : "red"
                                         border.color: "black"; border.width: 1
                                     }
                                 }
@@ -2029,7 +2029,7 @@ Rectangle {
 
                                 Rectangle {
                                     width: 20; height: 20; radius: 10
-                                    color: MOTIONInterface.consoleConnected ? "green" : "red"
+                                    color: MotionInterface.consoleConnected ? "green" : "red"
                                     border.color: "black"; border.width: 1
                                     Layout.alignment: Qt.AlignHCenter
                                 }
@@ -2071,7 +2071,7 @@ Rectangle {
 
                                 Rectangle {
                                     width: 20; height: 20; radius: 10
-                                    color: MOTIONInterface.safetyFailure ? "red" : "grey"
+                                    color: MotionInterface.safetyFailure ? "red" : "grey"
                                     border.color: "black"; border.width: 1
                                     Layout.alignment: Qt.AlignHCenter
                                 }
@@ -2089,18 +2089,18 @@ Rectangle {
         interval: 500
         running: false
         onTriggered: {            
-            if (MOTIONInterface.consoleConnected) {
+            if (MotionInterface.consoleConnected) {
                 // Load laser power config once per connect (deferred so overlay renders first)
                 if (!powerConfigLoaded) {
                     try {
-                        MOTIONInterface.setLaserPowerFromConfig();
+                        MotionInterface.setLaserPowerFromConfig();
                         powerConfigLoaded = true;
                     } catch (e) {
                         console.error("setLaserPowerFromConfig failed:", e);
                     }
                 }
 
-                const config = MOTIONInterface.queryTriggerConfig()
+                const config = MotionInterface.queryTriggerConfig()
                 if (config && Object.keys(config).length > 0) {
                     fsFrequency.text = config.TriggerFrequencyHz.toString()
                     fsPulseWidth.text = config.TriggerPulseWidthUsec.toString()
@@ -2114,9 +2114,9 @@ Rectangle {
         }
     }
     
-    // **Connections for MOTIONConnector signals**
+    // **Connections for MotionConnector signals**
     Connections {
-        target: MOTIONInterface
+        target: MotionInterface
 
         function onSignalConnected(descriptor, port) {
             // console.log(descriptor + " connected on " + port);
@@ -2147,9 +2147,9 @@ Rectangle {
         }
         
         function onConnectionStatusChanged() {          
-            if (MOTIONInterface.leftSensorConnected) {
+            if (MotionInterface.leftSensorConnected) {
             }   
-            if (MOTIONInterface.consoleConnected) {
+            if (MotionInterface.consoleConnected) {
                 demoLoading = true
                 consoleUpdateTimer.start()
             } else {
@@ -2158,18 +2158,18 @@ Rectangle {
         }
         
         function onLaserStateChanged() {          
-            if (MOTIONInterface.consoleConnected) {
+            if (MotionInterface.consoleConnected) {
             }            
         }
         
         function onSafetyFailureStateChanged() {          
-            if (MOTIONInterface.consoleConnected) {
+            if (MotionInterface.consoleConnected) {
             }            
         }
 
         function onIsStreamingChanged() {
-            cameraCapStatus.text = MOTIONInterface.isStreaming ? "Streaming" : "Stopped"
-            cameraCapStatus.color = MOTIONInterface.isStreaming ? "lightgreen" : "red"
+            cameraCapStatus.text = MotionInterface.isStreaming ? "Streaming" : "Stopped"
+            cameraCapStatus.color = MotionInterface.isStreaming ? "lightgreen" : "red"
         }
 
         function onUpdateCapStatus(message) {
@@ -2183,17 +2183,17 @@ Rectangle {
 
         // Apply FPGA scale overrides whenever user config is (re)loaded from device
         function onUserConfigLoaded(tecTrip, optGain, optThresh, eeGain, eeThresh) {
-            if (eeGain  > 0) MOTIONInterface.setScaleOverride("Safety EE",  "DRIVE CL", eeGain)
-            if (optGain > 0) MOTIONInterface.setScaleOverride("Safety OPT", "DRIVE CL", optGain)
+            if (eeGain  > 0) MotionInterface.setScaleOverride("Safety EE",  "DRIVE CL", eeGain)
+            if (optGain > 0) MotionInterface.setScaleOverride("Safety OPT", "DRIVE CL", optGain)
         }
 
     }
 
     // Run refresh logic immediately on page load if Sensor is already connected
     Component.onCompleted: {
-        if (MOTIONInterface.leftSensorConnected) {
+        if (MotionInterface.leftSensorConnected) {
         }
-        if (MOTIONInterface.consoleConnected) {
+        if (MotionInterface.consoleConnected) {
             demoLoading = true
             consoleUpdateTimer.start()
         }
@@ -2201,7 +2201,7 @@ Rectangle {
     }
 
     Component.onDestruction: {
-        // console.log("Closing UI, clearing MOTIONInterface...");
+        // console.log("Closing UI, clearing MotionInterface...");
     }
 
     Connections {

--- a/pages/Sensor.qml
+++ b/pages/Sensor.qml
@@ -64,8 +64,8 @@ Rectangle {
         // console.log("Sensor Updating all states...")
         
         let isConnected = (sensorSelector.currentIndex === 0)
-            ? MOTIONInterface.leftSensorConnected
-            : MOTIONInterface.rightSensorConnected
+            ? MotionInterface.leftSensorConnected
+            : MotionInterface.rightSensorConnected
 
         if (!isConnected) {
             // console.log("Selected sensor is not connected. Skipping update.")
@@ -75,22 +75,22 @@ Rectangle {
         let sensor_tag = (sensorSelector.currentIndex === 0) ? "left" : "right";
         // console.log("Sensor Updating all states for", sensor_tag);
         
-        MOTIONInterface.querySensorInfo(sensor_tag)
-        MOTIONInterface.querySensorTemperature(sensor_tag)
-        MOTIONInterface.querySensorAccelerometer(sensor_tag)
-        MOTIONInterface.queryCameraPowerStatus(sensor_tag)
-        //MOTIONInterface.queryTriggerInfo()
+        MotionInterface.querySensorInfo(sensor_tag)
+        MotionInterface.querySensorTemperature(sensor_tag)
+        MotionInterface.querySensorAccelerometer(sensor_tag)
+        MotionInterface.queryCameraPowerStatus(sensor_tag)
+        //MotionInterface.queryTriggerInfo()
     }
 
     // Run refresh logic immediately on page load if Sensor is already connected
     Component.onCompleted: {
         sensorSelector.currentIndex = 0 // default
-        if (MOTIONInterface.leftSensorConnected || MOTIONInterface.rightSensorConnected) {
+        if (MotionInterface.leftSensorConnected || MotionInterface.rightSensorConnected) {
             // console.log("Page Loaded - Sensor Already Connected. Fetching Info...");
             updateStates();
             // Also query camera power status for the selected sensor
             let sensor_tag = (sensorSelector.currentIndex === 0) ? "left" : "right";
-            MOTIONInterface.queryCameraPowerStatus(sensor_tag);
+            MotionInterface.queryCameraPowerStatus(sensor_tag);
             // Start fan status polling
             fanStatusTimer.start();
         }
@@ -114,11 +114,11 @@ Rectangle {
         onTriggered: {
             let sensor_tag = (sensorSelector.currentIndex === 0) ? "left" : "right";
             let isConnected = (sensorSelector.currentIndex === 0)
-                ? MOTIONInterface.leftSensorConnected
-                : MOTIONInterface.rightSensorConnected;
+                ? MotionInterface.leftSensorConnected
+                : MotionInterface.rightSensorConnected;
             
             if (isConnected) {
-                let currentFanStatus = MOTIONInterface.getFanControlStatus(sensor_tag);
+                let currentFanStatus = MotionInterface.getFanControlStatus(sensor_tag);
                 if (currentFanStatus !== fanControlOn) {
                     fanControlOn = currentFanStatus;
                     // console.log("Fan status updated:", currentFanStatus ? "ON" : "OFF");
@@ -128,15 +128,15 @@ Rectangle {
     }
 
     Connections {
-        target: MOTIONInterface
+        target: MotionInterface
 
         // Handle Sensor Connected state
         function onConnectionStatusChanged() {
-            if (MOTIONInterface.leftSensorConnected || MOTIONInterface.rightSensorConnected) {
+            if (MotionInterface.leftSensorConnected || MotionInterface.rightSensorConnected) {
                 infoTimer.start()          // One-time info fetch
                 // Automatically query camera power status when sensor connects
                 let sensor_tag = (sensorSelector.currentIndex === 0) ? "left" : "right";
-                MOTIONInterface.queryCameraPowerStatus(sensor_tag);
+                MotionInterface.queryCameraPowerStatus(sensor_tag);
                 // Start fan status polling
                 fanStatusTimer.start();
             } else {
@@ -260,7 +260,7 @@ Rectangle {
             
             TextField {
                 id: folderPathInput
-                text: MOTIONInterface.csvOutputDirectory
+                text: MotionInterface.csvOutputDirectory
                 Layout.fillWidth: true
                 placeholderText: "Enter folder path..."
                 selectByMouse: true
@@ -323,7 +323,7 @@ Rectangle {
                     
                     onClicked: {
                         if (folderPathInput.text.trim() !== "") {
-                            MOTIONInterface.setCsvOutputDirectory(folderPathInput.text.trim())
+                            MotionInterface.setCsvOutputDirectory(folderPathInput.text.trim())
                             csvFolderDialog.close()
                         }
                     }
@@ -406,9 +406,9 @@ Rectangle {
                                     hoverEnabled: true
                                     enabled: {
                                         if (sensorSelector.currentIndex === 0) {
-                                            return MOTIONInterface.leftSensorConnected
+                                            return MotionInterface.leftSensorConnected
                                         } else {
-                                            return MOTIONInterface.rightSensorConnected
+                                            return MotionInterface.rightSensorConnected
                                         }
                                     }
 
@@ -437,7 +437,7 @@ Rectangle {
 
                                     onClicked: {
                                         let sensor_tag = (sensorSelector.currentIndex === 0) ? "left" : "right";
-                                        if(MOTIONInterface.sendPingCommand(sensor_tag)){                                        
+                                        if(MotionInterface.sendPingCommand(sensor_tag)){                                        
                                             pingResult.text = "Ping SUCCESS"
                                             pingResult.color = "green"
                                         }else{
@@ -463,9 +463,9 @@ Rectangle {
                                     hoverEnabled: true
                                     enabled: {
                                         if (sensorSelector.currentIndex === 0) {
-                                            return MOTIONInterface.leftSensorConnected
+                                            return MotionInterface.leftSensorConnected
                                         } else {
-                                            return MOTIONInterface.rightSensorConnected
+                                            return MotionInterface.rightSensorConnected
                                         }
                                     }
 
@@ -494,7 +494,7 @@ Rectangle {
 
                                     onClicked: {
                                         let sensor_tag = (sensorSelector.currentIndex === 0) ? "left" : "right";
-                                        if(MOTIONInterface.sendEchoCommand(sensor_tag)) {
+                                        if(MotionInterface.sendEchoCommand(sensor_tag)) {
                                             echoResult.text = "Echo SUCCESS"
                                             echoResult.color = "green"
                                         } else {
@@ -520,9 +520,9 @@ Rectangle {
                                     hoverEnabled: true
                                     enabled: {
                                         if (sensorSelector.currentIndex === 0) {
-                                            return MOTIONInterface.leftSensorConnected
+                                            return MotionInterface.leftSensorConnected
                                         } else {
-                                            return MOTIONInterface.rightSensorConnected
+                                            return MotionInterface.rightSensorConnected
                                         }
                                     }
 
@@ -551,7 +551,7 @@ Rectangle {
 
                                     onClicked: {
                                         let sensor_tag = (sensorSelector.currentIndex === 0) ? "left" : "right";
-                                        if(MOTIONInterface.sendLedToggleCommand(sensor_tag)) {
+                                        if(MotionInterface.sendLedToggleCommand(sensor_tag)) {
                                             toggleLedResult.text = "LED Toggled"
                                             toggleLedResult.color = "green"
                                         } else {
@@ -581,9 +581,9 @@ Rectangle {
                                     hoverEnabled: true
                                     enabled: {
                                         if (sensorSelector.currentIndex === 0) {
-                                            return MOTIONInterface.leftSensorConnected
+                                            return MotionInterface.leftSensorConnected
                                         } else {
-                                            return MOTIONInterface.rightSensorConnected
+                                            return MotionInterface.rightSensorConnected
                                         }
                                     }
 
@@ -614,7 +614,7 @@ Rectangle {
                                         let sensor_tag = (sensorSelector.currentIndex === 0) ? "left" : "right";
                                         let newFanState = !fanControlOn;
                                         
-                                        if (MOTIONInterface.setFanControl(sensor_tag, newFanState)) {
+                                        if (MotionInterface.setFanControl(sensor_tag, newFanState)) {
                                             fanControlOn = newFanState;
                                             fanControlResult.text = newFanState ? "Fan ON" : "Fan OFF";
                                             fanControlResult.color = newFanState ? "green" : "orange";
@@ -926,9 +926,9 @@ Rectangle {
                                 currentIndex: 8  // Default to "All Cameras"
                                 enabled: {
                                     if (sensorSelector.currentIndex === 0) {
-                                        return MOTIONInterface.leftSensorConnected
+                                        return MotionInterface.leftSensorConnected
                                     } else {
-                                        return MOTIONInterface.rightSensorConnected
+                                        return MotionInterface.rightSensorConnected
                                     }
                                 }
 
@@ -961,9 +961,9 @@ Rectangle {
                                         hoverEnabled: true
                                         enabled: {
                                             if (sensorSelector.currentIndex === 0) {
-                                                return MOTIONInterface.leftSensorConnected
+                                                return MotionInterface.leftSensorConnected
                                             } else {
-                                                return MOTIONInterface.rightSensorConnected
+                                                return MotionInterface.rightSensorConnected
                                             }
                                         }
                                         contentItem: Text {
@@ -997,9 +997,9 @@ Rectangle {
                                     (sensorSelector.currentIndex === 0) ? sensor_tag = "left": sensor_tag = "right";
                                     // console.log("Test Camera Mask: " + cameraMask.toString(16));
                                     if(cameraMask == 0xFF){
-                                        MOTIONInterface.configureAllCameras(sensor_tag);
+                                        MotionInterface.configureAllCameras(sensor_tag);
                                     }else{
-                                        MOTIONInterface.configureCamera(sensor_tag, cameraMask);
+                                        MotionInterface.configureCamera(sensor_tag, cameraMask);
                                     }
                                         }
                                     }
@@ -1017,9 +1017,9 @@ Rectangle {
                                         hoverEnabled: true
                                         enabled: {
                                             if (sensorSelector.currentIndex === 0) {
-                                                return MOTIONInterface.leftSensorConnected
+                                                return MotionInterface.leftSensorConnected
                                             } else {
-                                                return MOTIONInterface.rightSensorConnected
+                                                return MotionInterface.rightSensorConnected
                                             }
                                         }
                                         contentItem: Text {
@@ -1069,7 +1069,7 @@ Rectangle {
                                                 }
                                                 
                                                 // console.log("Capturing histogram for camera", selectedIndex, "with SN", serialNumber);
-                                                    MOTIONInterface.captureHistogramToCSV(sensor_tag, selectedIndex, serialNumber, false);
+                                                    MotionInterface.captureHistogramToCSV(sensor_tag, selectedIndex, serialNumber, false);
                                             } else {
                                                 // All cameras - capture each individually with their serial numbers
                                                 // console.log("Capturing histograms for all cameras with individual serial numbers");
@@ -1097,7 +1097,7 @@ Rectangle {
                                                     serialNumbers.push(serialNumber);
                                                 }
                                                 
-                                                MOTIONInterface.captureAllCamerasHistogramToCSV(sensor_tag, false, serialNumbers);
+                                                MotionInterface.captureAllCamerasHistogramToCSV(sensor_tag, false, serialNumbers);
                                                 }
                                             }
                                         }
@@ -1110,9 +1110,9 @@ Rectangle {
                                             hoverEnabled: true
                                 enabled: {
                                     if (sensorSelector.currentIndex === 0) {
-                                        return MOTIONInterface.leftSensorConnected
+                                        return MotionInterface.leftSensorConnected
                                     } else {
-                                        return MOTIONInterface.rightSensorConnected
+                                        return MotionInterface.rightSensorConnected
                                     }
                                 }
                                             contentItem: Text {
@@ -1162,7 +1162,7 @@ Rectangle {
                                                     }
                                                     
                                                 // console.log("Capturing dark histogram for camera", selectedIndex, "with SN", serialNumber);
-                                                MOTIONInterface.captureHistogramToCSV(sensor_tag, selectedIndex, serialNumber, true);
+                                                MotionInterface.captureHistogramToCSV(sensor_tag, selectedIndex, serialNumber, true);
                                                 } else {
                                                     // All cameras - capture each individually with their serial numbers
                                                 // console.log("Capturing dark histograms for all cameras with individual serial numbers");
@@ -1190,7 +1190,7 @@ Rectangle {
                                                     serialNumbers.push(serialNumber);
                                                 }
                                                 
-                                                MOTIONInterface.captureAllCamerasHistogramToCSV(sensor_tag, true, serialNumbers);
+                                                MotionInterface.captureAllCamerasHistogramToCSV(sensor_tag, true, serialNumbers);
                                                 }
                                             }
                                         }
@@ -1237,9 +1237,9 @@ Rectangle {
                                         hoverEnabled: true
                                 enabled: {
                                     if (sensorSelector.currentIndex === 0) {
-                                        return MOTIONInterface.leftSensorConnected
+                                        return MotionInterface.leftSensorConnected
                                     } else {
-                                        return MOTIONInterface.rightSensorConnected
+                                        return MotionInterface.rightSensorConnected
                                     }
                                 }
                                 contentItem: Text {
@@ -1266,11 +1266,11 @@ Rectangle {
                                 onClicked: {
                                             let target = "left";
                                             (sensorSelector.currentIndex === 0) ? target = "left": target = "right";
-                                            MOTIONInterface.powerCamerasOn(target)
+                                            MotionInterface.powerCamerasOn(target)
                                             
                                             // Automatically query power status after powering on
                                             let sensor_tag = (sensorSelector.currentIndex === 0) ? "left" : "right";
-                                            MOTIONInterface.queryCameraPowerStatus(sensor_tag)
+                                            MotionInterface.queryCameraPowerStatus(sensor_tag)
                                         }
                                     }
                                     }
@@ -1294,9 +1294,9 @@ Rectangle {
                                         hoverEnabled: true
                                         enabled: {
                                             if (sensorSelector.currentIndex === 0) {
-                                                return MOTIONInterface.leftSensorConnected
+                                                return MotionInterface.leftSensorConnected
                                             } else {
-                                                return MOTIONInterface.rightSensorConnected
+                                                return MotionInterface.rightSensorConnected
                                             }
                                         }
                                         contentItem: Text {
@@ -1323,11 +1323,11 @@ Rectangle {
                                         onClicked: {
                                             let target = "left";
                                             (sensorSelector.currentIndex === 0) ? target = "left": target = "right";
-                                            MOTIONInterface.powerCamerasOff(target)
+                                            MotionInterface.powerCamerasOff(target)
                                             
                                             // Automatically query power status after powering off
                                             let sensor_tag = (sensorSelector.currentIndex === 0) ? "left" : "right";
-                                            MOTIONInterface.queryCameraPowerStatus(sensor_tag)
+                                            MotionInterface.queryCameraPowerStatus(sensor_tag)
                                         }
                                     }
                                     }
@@ -1349,14 +1349,14 @@ Rectangle {
 
                                 Text {
                                     id: csvOutputPathText
-                                    text: MOTIONInterface.csvOutputDirectory
+                                    text: MotionInterface.csvOutputDirectory
                                     color: "#3498DB"
                                     font.pixelSize: 12
                                     Layout.fillWidth: true
                                     elide: Text.ElideMiddle
                                     onTextChanged: {
                                         // Update text when directory changes
-                                        text = MOTIONInterface.csvOutputDirectory
+                                        text = MotionInterface.csvOutputDirectory
                                     }
                                 }
 
@@ -1487,9 +1487,9 @@ Rectangle {
                                 radius: 10
                                 color: {
                                     if (sensorSelector.currentIndex === 0) {
-                                        return MOTIONInterface.leftSensorConnected ? "green" : "red"
+                                        return MotionInterface.leftSensorConnected ? "green" : "red"
                                     } else {
-                                        return MOTIONInterface.rightSensorConnected ? "green" : "red"
+                                        return MotionInterface.rightSensorConnected ? "green" : "red"
                                     }
                                 }
                                 border.color: "black"
@@ -1511,9 +1511,9 @@ Rectangle {
                                 Layout.alignment: Qt.AlignRight  
                                 enabled: {
                                     if (sensorSelector.currentIndex === 0) {
-                                        return MOTIONInterface.leftSensorConnected
+                                        return MotionInterface.leftSensorConnected
                                     } else {
-                                        return MOTIONInterface.rightSensorConnected
+                                        return MotionInterface.rightSensorConnected
                                     }
                                 }
 
@@ -1601,9 +1601,9 @@ Rectangle {
                             color: enabled ? "#E74C3C" : "#7F8C8D"  // Red when enabled, gray when disabled
                             enabled: {
                                     if (sensorSelector.currentIndex === 0) {
-                                        return MOTIONInterface.leftSensorConnected
+                                        return MotionInterface.leftSensorConnected
                                     } else {
-                                        return MOTIONInterface.rightSensorConnected
+                                        return MotionInterface.rightSensorConnected
                                     }
                             }
                             Text {
@@ -1621,7 +1621,7 @@ Rectangle {
                                     let sensor_tag = "left";
                                     (sensorSelector.currentIndex === 0) ? sensor_tag = "left": sensor_tag = "right";
                                     // console.log("Soft Reset Triggered")
-                                    MOTIONInterface.softResetSensor(sensor_tag)
+                                    MotionInterface.softResetSensor(sensor_tag)
                                 }
 
                                 onEntered: {

--- a/pages/Settings.qml
+++ b/pages/Settings.qml
@@ -78,7 +78,7 @@ Rectangle {
     property string fpgaFwUploadTarget: ""
 
     function _startFpgaUpdate(target, tag) {
-        if (!MOTIONInterface.consoleConnected) {
+        if (!MotionInterface.consoleConnected) {
             fwErrorDialog.message = "Console is not connected."
             fwErrorDialog.open()
             return
@@ -91,12 +91,12 @@ Rectangle {
         fpgaFwUpdateTarget = target
         fpgaFwPercent = -1
         fpgaFwMessage = "Starting..."
-        MOTIONInterface.beginFpgaFirmwareUpdate(target, tag)
+        MotionInterface.beginFpgaFirmwareUpdate(target, tag)
         fpgaProgressDialog.open()
     }
 
     function _startFpgaFromLocal(target) {
-        if (!MOTIONInterface.consoleConnected) {
+        if (!MotionInterface.consoleConnected) {
             fwErrorDialog.message = "Console is not connected."
             fwErrorDialog.open()
             return
@@ -123,32 +123,32 @@ Rectangle {
     }
 
     function refreshConsoleInfo() {
-        if (MOTIONInterface.consoleConnected) {
-            MOTIONInterface.queryConsoleInfo()
-            MOTIONInterface.queryConsoleLatestVersionInfo()
+        if (MotionInterface.consoleConnected) {
+            MotionInterface.queryConsoleInfo()
+            MotionInterface.queryConsoleLatestVersionInfo()
         }
     }
 
     function refreshFpgaInfo() {
-        if (MOTIONInterface.consoleConnected) {
-            MOTIONInterface.queryFpgaVersions()
-            MOTIONInterface.queryConsoleLatestFpgaVersionInfo()
+        if (MotionInterface.consoleConnected) {
+            MotionInterface.queryFpgaVersions()
+            MotionInterface.queryConsoleLatestFpgaVersionInfo()
         }
     }
 
     function refreshSensorInfo(target) {
-        if (target === "left" && MOTIONInterface.leftSensorConnected) {
-            MOTIONInterface.querySensorInfo(target)
-            MOTIONInterface.querySensorLatestVersionInfo(target)
+        if (target === "left" && MotionInterface.leftSensorConnected) {
+            MotionInterface.querySensorInfo(target)
+            MotionInterface.querySensorLatestVersionInfo(target)
         }
-        if (target === "right" && MOTIONInterface.rightSensorConnected) {
-            MOTIONInterface.querySensorInfo(target)
-            MOTIONInterface.querySensorLatestVersionInfo(target)
+        if (target === "right" && MotionInterface.rightSensorConnected) {
+            MotionInterface.querySensorInfo(target)
+            MotionInterface.querySensorLatestVersionInfo(target)
         }
     }
 
     Connections {
-        target: MOTIONInterface
+        target: MotionInterface
 
         function _clearConsoleInfo() {
             consoleFirmwareVersion = "N/A"
@@ -176,17 +176,17 @@ Rectangle {
         // Mirrors Sensor.qml/Console.qml behavior: on any connection change, clear disconnected
         // fields immediately and query device info for connected modules.
         function onConnectionStatusChanged() {
-            if (!MOTIONInterface.consoleConnected) {
+            if (!MotionInterface.consoleConnected) {
                 _clearConsoleInfo()
                 userConfigLoading = false
             }
-            if (!MOTIONInterface.leftSensorConnected)
+            if (!MotionInterface.leftSensorConnected)
                 _clearLeftSensorInfo()
-            if (!MOTIONInterface.rightSensorConnected)
+            if (!MotionInterface.rightSensorConnected)
                 _clearRightSensorInfo()
 
-            if (MOTIONInterface.consoleConnected || MOTIONInterface.leftSensorConnected || MOTIONInterface.rightSensorConnected) {
-                if (MOTIONInterface.consoleConnected)
+            if (MotionInterface.consoleConnected || MotionInterface.leftSensorConnected || MotionInterface.rightSensorConnected) {
+                if (MotionInterface.consoleConnected)
                     userConfigLoading = true
                 settingsInfoTimer.restart()
             } else {
@@ -365,7 +365,7 @@ Rectangle {
                 fwResultDialog.message = message
                 fwResultDialog.open()
                 // Refresh current versions after successful reprogramming.
-                MOTIONInterface.queryFpgaVersions()
+                MotionInterface.queryFpgaVersions()
             }
         }
 
@@ -402,15 +402,15 @@ Rectangle {
             refreshFpgaInfo()
             refreshSensorInfo("left")
             refreshSensorInfo("right")
-            if (MOTIONInterface.consoleConnected)
-                MOTIONInterface.readUserConfig()
+            if (MotionInterface.consoleConnected)
+                MotionInterface.readUserConfig()
         }
     }
 
     Component.onCompleted: {
         // Populate immediately if user navigates here while already connected
-        if (MOTIONInterface.consoleConnected || MOTIONInterface.leftSensorConnected || MOTIONInterface.rightSensorConnected) {
-            if (MOTIONInterface.consoleConnected)
+        if (MotionInterface.consoleConnected || MotionInterface.leftSensorConnected || MotionInterface.rightSensorConnected) {
+            if (MotionInterface.consoleConnected)
                 userConfigLoading = true
             settingsInfoTimer.start()
         }
@@ -571,7 +571,7 @@ Rectangle {
             consoleFwPercent = -1
             consoleFwMessage = ""
             consoleFwStageText = ""
-            MOTIONInterface.beginDeviceFirmwareFromLocal(fwUploadTarget, file)
+            MotionInterface.beginDeviceFirmwareFromLocal(fwUploadTarget, file)
         }
     }
 
@@ -599,7 +599,7 @@ Rectangle {
 
             fpgaFwPercent = -1
             fpgaFwMessage = ""
-            MOTIONInterface.beginFpgaFirmwareFromLocal(fpgaFwUploadTarget, file)
+            MotionInterface.beginFpgaFirmwareFromLocal(fpgaFwUploadTarget, file)
             fpgaProgressDialog.open()
         }
     }
@@ -796,7 +796,7 @@ Rectangle {
 
                     onClicked: {
                         fwConfirmDialog.close()
-                        MOTIONInterface.cancelConsoleFirmwareUpdate(consoleFwToken)
+                        MotionInterface.cancelConsoleFirmwareUpdate(consoleFwToken)
                         consoleFwToken = ""
                     }
 
@@ -824,7 +824,7 @@ Rectangle {
                     onClicked: {
                         fwConfirmDialog.close()
                         fwProgressDialog.open()
-                        MOTIONInterface.startConsoleFirmwareUpdate(consoleFwToken)
+                        MotionInterface.startConsoleFirmwareUpdate(consoleFwToken)
                     }
 
                     contentItem: Text {
@@ -1061,14 +1061,14 @@ Rectangle {
                             Text { text: "" + appVersion; color: "#3498DB"; font.pixelSize: 14; elide: Text.ElideRight; Layout.fillWidth: true }
 
                             Text { text: "SDK Version:"; color: "#BDC3C7"; font.pixelSize: 14; horizontalAlignment: Text.AlignLeft; Layout.preferredWidth: 120 }
-                            Text { text: "" + MOTIONInterface.get_sdk_version(); color: "#3498DB"; font.pixelSize: 14; elide: Text.ElideRight; Layout.fillWidth: true }
+                            Text { text: "" + MotionInterface.get_sdk_version(); color: "#3498DB"; font.pixelSize: 14; elide: Text.ElideRight; Layout.fillWidth: true }
 
                             Text { text: "System State:"; color: "#BDC3C7"; font.pixelSize: 14; horizontalAlignment: Text.AlignLeft; Layout.preferredWidth: 120 }
                             Text {
                                 text: {
-                                    const c = MOTIONInterface.consoleConnected
-                                    const l = MOTIONInterface.leftSensorConnected
-                                    const r = MOTIONInterface.rightSensorConnected
+                                    const c = MotionInterface.consoleConnected
+                                    const l = MotionInterface.leftSensorConnected
+                                    const r = MotionInterface.rightSensorConnected
                                     if (c && l && r) return "Connected"
                                     if (!c && !l && !r) return "Disconnected"
                                     return "Partially Connected"
@@ -1165,7 +1165,7 @@ Rectangle {
                                 MouseArea {
                                     id: loadJsonMA; anchors.fill: parent; hoverEnabled: true
                                     onClicked: {
-                                        MOTIONInterface.readUserConfig()
+                                        MotionInterface.readUserConfig()
                                         jsonStatus.text = "Loading..."
                                     }
                                 }
@@ -1179,7 +1179,7 @@ Rectangle {
                                 MouseArea {
                                     id: saveJsonMA; anchors.fill: parent; hoverEnabled: true
                                     onClicked: {
-                                        MOTIONInterface.setUserConfigJson(userConfigJsonArea.text)
+                                        MotionInterface.setUserConfigJson(userConfigJsonArea.text)
                                         jsonStatus.text = "Saving..."
                                     }
                                 }
@@ -1226,7 +1226,7 @@ Rectangle {
                                 Text { text: "FPGAs"; font.pixelSize: 16; color: "#BDC3C7" }
                                 Rectangle {
                                     width: 14; height: 14; radius: 7
-                                    color: MOTIONInterface.consoleConnected ? "green" : "red"
+                                    color: MotionInterface.consoleConnected ? "green" : "red"
                                     border.color: "black"; border.width: 1
                                 }
                             }
@@ -1234,7 +1234,7 @@ Rectangle {
                             Rectangle {
                                 width: 30; height: 30; radius: 15
                                 color: enabled ? "#2C3E50" : "#7F8C8D"
-                                enabled: MOTIONInterface.consoleConnected
+                                enabled: MotionInterface.consoleConnected
 
                                 Text {
                                     text: "\u21BB"
@@ -1282,7 +1282,7 @@ Rectangle {
                                     Rectangle {
                                         width: 70; height: 28; radius: 8
                                         color: enabled ? "#E74C3C" : "#7F8C8D"
-                                        enabled: MOTIONInterface.consoleConnected && !MOTIONInterface.fpgaFirmwareUpdateBusy
+                                        enabled: MotionInterface.consoleConnected && !MotionInterface.fpgaFirmwareUpdateBusy
                                         Text { anchors.centerIn: parent; text: "Update"; color: parent.enabled ? "white" : "#BDC3C7"; font.pixelSize: 13; font.weight: Font.Bold }
                                         MouseArea {
                                             anchors.fill: parent; enabled: parent.enabled
@@ -1337,7 +1337,7 @@ Rectangle {
                                     Rectangle {
                                         width: 70; height: 28; radius: 8
                                         color: enabled ? "#E74C3C" : "#7F8C8D"
-                                        enabled: MOTIONInterface.consoleConnected && !MOTIONInterface.fpgaFirmwareUpdateBusy
+                                        enabled: MotionInterface.consoleConnected && !MotionInterface.fpgaFirmwareUpdateBusy
                                         Text { anchors.centerIn: parent; text: "Update"; color: parent.enabled ? "white" : "#BDC3C7"; font.pixelSize: 13; font.weight: Font.Bold }
                                         MouseArea {
                                             anchors.fill: parent; enabled: parent.enabled
@@ -1392,7 +1392,7 @@ Rectangle {
                                     Rectangle {
                                         width: 70; height: 28; radius: 8
                                         color: enabled ? "#E74C3C" : "#7F8C8D"
-                                        enabled: MOTIONInterface.consoleConnected && !MOTIONInterface.fpgaFirmwareUpdateBusy
+                                        enabled: MotionInterface.consoleConnected && !MotionInterface.fpgaFirmwareUpdateBusy
                                         Text { anchors.centerIn: parent; text: "Update"; color: parent.enabled ? "white" : "#BDC3C7"; font.pixelSize: 13; font.weight: Font.Bold }
                                         MouseArea {
                                             anchors.fill: parent; enabled: parent.enabled
@@ -1453,7 +1453,7 @@ Rectangle {
                                     Rectangle {
                                         width: 70; height: 28; radius: 8
                                         color: enabled ? "#E74C3C" : "#7F8C8D"
-                                        enabled: MOTIONInterface.consoleConnected && !MOTIONInterface.fpgaFirmwareUpdateBusy
+                                        enabled: MotionInterface.consoleConnected && !MotionInterface.fpgaFirmwareUpdateBusy
                                         Text { anchors.centerIn: parent; text: "Update"; color: parent.enabled ? "white" : "#BDC3C7"; font.pixelSize: 13; font.weight: Font.Bold }
                                         MouseArea {
                                             anchors.fill: parent; enabled: parent.enabled
@@ -1499,8 +1499,8 @@ Rectangle {
                     CheckBox {
                         id: fpgaVerifyOverlay
                         text: "Verify"
-                        checked: MOTIONInterface.fpgaFirmwareVerifyEnabled
-                        enabled: MOTIONInterface.consoleConnected && !MOTIONInterface.fpgaFirmwareUpdateBusy
+                        checked: MotionInterface.fpgaFirmwareVerifyEnabled
+                        enabled: MotionInterface.consoleConnected && !MotionInterface.fpgaFirmwareUpdateBusy
                         indicator.width: 16
                         indicator.height: 16
                         font.pixelSize: 13
@@ -1509,7 +1509,7 @@ Rectangle {
                         anchors.bottom: parent.bottom
                         anchors.bottomMargin: 8
 
-                        onToggled: MOTIONInterface.fpgaFirmwareVerifyEnabled = checked
+                        onToggled: MotionInterface.fpgaFirmwareVerifyEnabled = checked
 
                         ToolTip.visible: hovered
                         ToolTip.text: "Enable FPGA post-program verify (slower)"
@@ -1555,7 +1555,7 @@ Rectangle {
                                     width: 14
                                     height: 14
                                     radius: 7
-                                    color: MOTIONInterface.consoleConnected ? "green" : "red"
+                                    color: MotionInterface.consoleConnected ? "green" : "red"
                                     border.color: "black"
                                     border.width: 1
                                 }
@@ -1567,7 +1567,7 @@ Rectangle {
                                     height: 30
                                     radius: 15
                                     color: enabled ? "#2C3E50" : "#7F8C8D"
-                                    enabled: MOTIONInterface.consoleConnected
+                                    enabled: MotionInterface.consoleConnected
 
                                     Text {
                                         text: "\u21BB"
@@ -1623,7 +1623,7 @@ Rectangle {
                                     currentIndex: consoleLatestIndex
                                     Layout.fillWidth: true
                                     Layout.preferredHeight: 32
-                                    enabled: MOTIONInterface.consoleConnected
+                                    enabled: MotionInterface.consoleConnected
                                     onCurrentIndexChanged: consoleLatestIndex = currentIndex
                                 }
                             }
@@ -1635,11 +1635,11 @@ Rectangle {
                                 height: 40
                                 radius: 10
                                 color: enabled ? "#E74C3C" : "#7F8C8D"
-                                enabled: MOTIONInterface.consoleConnected
+                                enabled: MotionInterface.consoleConnected
                                     && consoleFirmwareVersion !== "N/A"
                                     && consoleDeviceId !== "N/A"
                                     && consoleBoardRevId !== "N/A"
-                                    && !MOTIONInterface.consoleFirmwareUpdateBusy
+                                    && !MotionInterface.consoleFirmwareUpdateBusy
 
                                 Text {
                                     text: "Update Firmware"
@@ -1664,7 +1664,7 @@ Rectangle {
                                         consoleFwPercent = -1
                                         consoleFwMessage = ""
                                         consoleFwStageText = "Starting…"
-                                        MOTIONInterface.beginConsoleFirmwareDownload(tag)
+                                        MotionInterface.beginConsoleFirmwareDownload(tag)
                                         fwProgressDialog.open()
                                     }
                                     onEntered: if (parent.enabled) parent.color = "#C0392B"
@@ -1700,7 +1700,7 @@ Rectangle {
                                     width: 14
                                     height: 14
                                     radius: 7
-                                    color: MOTIONInterface.leftSensorConnected ? "green" : "red"
+                                    color: MotionInterface.leftSensorConnected ? "green" : "red"
                                     border.color: "black"
                                     border.width: 1
                                 }
@@ -1712,7 +1712,7 @@ Rectangle {
                                     height: 30
                                     radius: 15
                                     color: enabled ? "#2C3E50" : "#7F8C8D"
-                                    enabled: MOTIONInterface.leftSensorConnected
+                                    enabled: MotionInterface.leftSensorConnected
 
                                     Text {
                                         text: "\u21BB"
@@ -1765,7 +1765,7 @@ Rectangle {
                                     currentIndex: leftLatestIndex
                                     Layout.fillWidth: true
                                     Layout.preferredHeight: 32
-                                    enabled: MOTIONInterface.leftSensorConnected && leftReleasesModel.length > 0
+                                    enabled: MotionInterface.leftSensorConnected && leftReleasesModel.length > 0
                                     onCurrentIndexChanged: leftLatestIndex = currentIndex
                                 }
                             }
@@ -1777,7 +1777,7 @@ Rectangle {
                                 height: 40
                                 radius: 10
                                 color: enabled ? "#E74C3C" : "#7F8C8D"
-                                enabled: MOTIONInterface.leftSensorConnected
+                                enabled: MotionInterface.leftSensorConnected
                                     && leftSensorFirmwareVersion !== "N/A"
                                     && leftSensorDeviceId !== "N/A"
 
@@ -1804,7 +1804,7 @@ Rectangle {
                                         consoleFwPercent = -1
                                         consoleFwMessage = ""
                                         consoleFwStageText = "Starting…"
-                                        MOTIONInterface.beginDeviceFirmwareDownload("left", tag)
+                                        MotionInterface.beginDeviceFirmwareDownload("left", tag)
                                         fwProgressDialog.open()
                                     }
                                     onEntered: if (parent.enabled) parent.color = "#C0392B"
@@ -1840,7 +1840,7 @@ Rectangle {
                                     width: 14
                                     height: 14
                                     radius: 7
-                                    color: MOTIONInterface.rightSensorConnected ? "green" : "red"
+                                    color: MotionInterface.rightSensorConnected ? "green" : "red"
                                     border.color: "black"
                                     border.width: 1
                                 }
@@ -1852,7 +1852,7 @@ Rectangle {
                                     height: 30
                                     radius: 15
                                     color: enabled ? "#2C3E50" : "#7F8C8D"
-                                    enabled: MOTIONInterface.rightSensorConnected
+                                    enabled: MotionInterface.rightSensorConnected
 
                                     Text {
                                         text: "\u21BB"
@@ -1905,7 +1905,7 @@ Rectangle {
                                     currentIndex: rightLatestIndex
                                     Layout.fillWidth: true
                                     Layout.preferredHeight: 32
-                                    enabled: MOTIONInterface.rightSensorConnected && rightReleasesModel.length > 0
+                                    enabled: MotionInterface.rightSensorConnected && rightReleasesModel.length > 0
                                     onCurrentIndexChanged: rightLatestIndex = currentIndex
                                 }
                             }
@@ -1917,7 +1917,7 @@ Rectangle {
                                 height: 40
                                 radius: 10
                                 color: enabled ? "#E74C3C" : "#7F8C8D"
-                                enabled: MOTIONInterface.rightSensorConnected
+                                enabled: MotionInterface.rightSensorConnected
                                     && rightSensorFirmwareVersion !== "N/A"
                                     && rightSensorDeviceId !== "N/A"
 
@@ -1944,7 +1944,7 @@ Rectangle {
                                         consoleFwPercent = -1
                                         consoleFwMessage = ""
                                         consoleFwStageText = "Starting…"
-                                        MOTIONInterface.beginDeviceFirmwareDownload("right", tag)
+                                        MotionInterface.beginDeviceFirmwareDownload("right", tag)
                                         fwProgressDialog.open()
                                     }
                                     onEntered: if (parent.enabled) parent.color = "#C0392B"

--- a/scripts/generate_sbom.py
+++ b/scripts/generate_sbom.py
@@ -15,7 +15,7 @@ OUTPUT_FILE = REPO_ROOT / "sbom.cyclonedx.json"
 
 PROJECT_NAME = "openmotion-test-app"
 PROJECT_DESCRIPTION = (
-    "Qt/QML desktop hardware test application for OpenMOTION blood flow volume "
+    "Qt/QML desktop hardware test application for Open-Motion blood flow volume "
     "and index measurement workflows."
 )
 PROJECT_LICENSE = "AGPL-3.0-only"
@@ -40,7 +40,7 @@ EXTERNAL_COMPONENTS = [
         "name": "libusb",
         "scope": "required",
         "type": "library",
-        "description": "USB runtime dependency required by the OpenMOTION SDK and packaging flow on Windows.",
+        "description": "USB runtime dependency required by the Open-Motion SDK and packaging flow on Windows.",
         "source": "https://github.com/libusb/libusb",
         "evidence": [
             "README.md",
@@ -282,7 +282,7 @@ def generate_sbom() -> dict:
                 "externalReferences": [
                     {
                         "type": "vcs",
-                        "url": "https://github.com/OpenwaterHealth/OpenMOTION-TestAPP",
+                        "url": "https://github.com/OpenwaterHealth/openmotion-test-app",
                     }
                 ],
                 "properties": [


### PR DESCRIPTION
## Summary
- `MOTIONConnector` class → `MotionConnector` in `motion_connector.py`.
- QML singleton registration `qmlRegisterSingletonInstance("OpenMotion", 1, 0, "MOTIONInterface", connector)` → `"MotionInterface"`; ~280 QML references updated across `pages/Console.qml`, `pages/Sensor.qml`, `pages/Demo.qml`, `pages/Settings.qml`, and `components/`.
- Product-name strings switched to brand-correct `Open-Motion` hyphenation (window title, demo header, SBOM description, README title, argparse description, "Starting MOTION monitoring" log line).
- Stale repo URL refs (`OpenMOTION-Pylib`, `OpenMOTION-TestAPP`) swapped for actual repo names (`openmotion-sdk`, `openmotion-test-app`).

No behavior change. CRLF line endings preserved. `sbom.cdx.json` left alone (auto-regenerated by the build).

## Test plan
- [x] `py_compile` clean on `motion_connector.py`, `main.py`, `fpga_laser_config.py`, `scripts/generate_sbom.py`.
- [ ] Launch test-app and confirm the QML loads (QML singleton name change is the highest-risk part of the rename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)