### PR TITLE
fix: refresh odometer reading after reset in Console page

### DIFF
--- a/pages/Console.qml
+++ b/pages/Console.qml
@@ -1589,6 +1589,10 @@ Rectangle {
                         var ok = MOTIONInterface.resetOdometer(2)  // 2 = both counters
                         odometerResetResultDialog.success = ok
                         odometerResetResultDialog.open()
+                        // Refresh the displayed counters from the console so the
+                        // panel reflects the cleared state (consoleOdometerReceived).
+                        if (ok)
+                            MOTIONInterface.queryConsoleOdometer()
                     }
                 }
             }


### PR DESCRIPTION
## What

The **Reset Odometer** handler on the Console page reset the console's lifetime counters but never re-queried them, so the panel kept displaying the *stale* values until a reconnect or page reload. `updateStates()` (which reads the odometer) only fires once on console-connect via `infoTimer` — it is **not** on a repeating timer, so nothing refreshed the panel after a reset.

This adds a re-query on a successful reset so the display reflects the cleared state immediately:

```qml
odometerResetResultDialog.open()
// Refresh the displayed counters from the console so the
// panel reflects the cleared state (consoleOdometerReceived).
if (ok)
    MOTIONInterface.queryConsoleOdometer()
```

## Verification

Hand-verified on connected hardware (console on COM12):
- Pre-reset panel: **Uptime 17.7 h / Laser pulses 223,573**
- Clicked Reset Odometer → confirmed → result dialog reported success, and the panel **immediately refreshed to 0.0 h / 0** (a fresh firmware read, confirming the reset persisted).
- Probe: a second reset on already-zeroed counters still reports success and stays at 0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)