### PR TITLE
Release: next → main (odometer reset refresh + persistent app logging)

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,12 +3,24 @@ import os
 import warnings
 import logging
 import argparse
+
+# PyInstaller --windowed/--noconsole builds set sys.stdout and sys.stderr to
+# None (no console attached). Any code that does sys.stdout.write(...) —
+# including logging.StreamHandler — then raises AttributeError on first use.
+# Redirect None streams to a safe sink BEFORE any logging is configured or any
+# import that might attach a logger runs.
+if sys.stdout is None:
+    sys.stdout = open(os.devnull, "w", encoding="utf-8", buffering=1)
+if sys.stderr is None:
+    sys.stderr = open(os.devnull, "w", encoding="utf-8", buffering=1)
+
 from PyQt6.QtGui import QGuiApplication, QIcon
 from PyQt6.QtQml import QQmlApplicationEngine, qmlRegisterSingletonInstance
 
 from motion_connector import MOTIONConnector
 from motion_singleton import motion_interface
 from version import get_version
+from utils.log_setup import configure_app_logging
 
 # set PYTHONPATH=%cd%\..\OpenMOTION-PyLib;%PYTHONPATH%
 # python main.py
@@ -50,26 +62,13 @@ def main():
     )
     args = parser.parse_args()
 
-    # Configure logging based on debug flag
+    # Configure logging: console + a timestamped file under <root>/app-logs/.
+    # Written on every launch, not just --debug. (Noisy SDK loggers are pinned
+    # to INFO inside configure_app_logging.)
+    logfile_path = configure_app_logging(args.debug, APP_VERSION)
     if args.debug:
-        logging.basicConfig(
-            level=logging.DEBUG,
-            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-            handlers=[
-                logging.StreamHandler(sys.stdout),  # Console output
-                logging.FileHandler("debug.log"),  # File output
-            ],
-        )
         logger.info("Debug mode enabled - logging level set to DEBUG")
-        # Wire-level and polling logs flood DEBUG output (one line per USB
-        # packet / telemetry tick); keep them at INFO unless hand-edited.
-        for noisy in ("openmotion.sdk.CommInterface",
-                      "openmotion.sdk.ConsoleTelemetry",
-                      "openmotion.sdk.UARTPACKET",
-                      "openmotion.sdk.Sensor"):
-            logging.getLogger(noisy).setLevel(logging.INFO)
-    else:
-        logging.basicConfig(level=logging.INFO)
+    logger.info("Logging to %s", logfile_path)
 
     os.environ["QT_QUICK_CONTROLS_STYLE"] = "Material"
     os.environ["QT_QUICK_CONTROLS_MATERIAL_THEME"] = "Dark"

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -1403,51 +1403,20 @@ class MOTIONConnector(QObject):
         self._set_console_fw_busy(False)
 
     def _configure_logging(self, log_level):
-        """Configure logging for motion_connector with the specified log level."""
+        """Set up the connector's module loggers.
+
+        Console + file handlers are owned by main.py (``configure_app_logging``
+        in utils/log_setup.py), which configures the root logger. The
+        ``ow-testapp`` logger just propagates its records up to root.
+        """
         global logger, run_logger
 
-        # Get logger instance
         logger = logging.getLogger("ow-testapp")
         logger.setLevel(log_level)
+        logger.propagate = True
 
-        # Common formatter
-        formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
-
-        # Configure handlers - ensure console output for debug messages
-        if not logger.hasHandlers():
-            # Check if root logger has handlers (main.py configured logging)
-            root_logger = logging.getLogger()
-            if root_logger.handlers:
-                # Let messages propagate to root logger (main.py handles console/file output)
-                logger.propagate = True
-            else:
-                # No root handlers, set up our own console handler
-                console_handler = logging.StreamHandler()
-                console_handler.setLevel(log_level)
-                console_handler.setFormatter(formatter)
-                logger.addHandler(console_handler)
-
-                # Also add file handler for local logging
-                run_dir = os.path.join(os.getcwd(), "app-logs")
-                os.makedirs(run_dir, exist_ok=True)
-
-                # Build timestamp like 20251029_124455
-                ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-
-                # ow-testapp-<ts>.log
-                logfile_path = os.path.join(run_dir, f"ow-testapp-{ts}.log")
-
-                file_handler = logging.FileHandler(
-                    logfile_path, mode="w", encoding="utf-8"
-                )
-                file_handler.setLevel(log_level)
-                file_handler.setFormatter(formatter)
-                logger.addHandler(file_handler)
-
-                # Optional: announce where we're logging
-                logger.info(f"logging to {logfile_path}")
-
-        # Run logger (ONLY writes to run.log, no console spam)
+        # Run logger: isolated from root so it doesn't reach the console/file
+        # handlers (kept for callers that wire it up separately).
         run_logger = logging.getLogger("runlog")
         run_logger.setLevel(log_level)
         run_logger.propagate = False

--- a/pages/Console.qml
+++ b/pages/Console.qml
@@ -1589,6 +1589,10 @@ Rectangle {
                         var ok = MOTIONInterface.resetOdometer(2)  // 2 = both counters
                         odometerResetResultDialog.success = ok
                         odometerResetResultDialog.open()
+                        // Refresh the displayed counters from the console so the
+                        // panel reflects the cleared state (consoleOdometerReceived).
+                        if (ok)
+                            MOTIONInterface.queryConsoleOdometer()
                     }
                 }
             }

--- a/tests/test_log_setup.py
+++ b/tests/test_log_setup.py
@@ -1,0 +1,112 @@
+"""Unit tests for utils.log_setup.configure_app_logging.
+
+Run from the repo root with:  python -m pytest tests/test_log_setup.py
+(`python -m pytest` puts the repo root on sys.path so `import utils.*` works.)
+"""
+import logging
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def clean_root_logger():
+    """Isolate the global root logger: strip its handlers for the duration of
+    the test, then close+restore so we don't leak file handles (Windows locks
+    the log file otherwise) or pollute other tests."""
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
+    for h in saved_handlers:
+        root.removeHandler(h)
+    yield root
+    for h in root.handlers[:]:
+        root.removeHandler(h)
+        try:
+            h.close()
+        except Exception:
+            pass
+    for h in saved_handlers:
+        root.addHandler(h)
+    root.setLevel(saved_level)
+
+
+def test_creates_timestamped_logfile_under_app_logs(tmp_path, monkeypatch, clean_root_logger):
+    from utils.log_setup import configure_app_logging
+
+    monkeypatch.chdir(tmp_path)
+    path = configure_app_logging(debug=False, app_version="9.9.9")
+
+    p = Path(path)
+    assert p.is_file(), "log file should be created on disk"
+    assert p.parent == (tmp_path / "app-logs").resolve()
+    assert p.name.startswith("ow-testapp-")
+    assert p.suffix == ".log"
+
+
+def test_attaches_console_and_file_handlers_to_root(tmp_path, monkeypatch, clean_root_logger):
+    from utils.log_setup import configure_app_logging
+
+    monkeypatch.chdir(tmp_path)
+    # pytest's logging plugin attaches its own capture handlers to root, so
+    # measure only the handlers configure_app_logging itself adds.
+    before = {id(h) for h in clean_root_logger.handlers}
+    configure_app_logging(debug=False, app_version="9.9.9")
+    added = [h for h in clean_root_logger.handlers if id(h) not in before]
+
+    file_handlers = [h for h in added if isinstance(h, logging.FileHandler)]
+    # A FileHandler is a StreamHandler subclass, so exclude it when counting consoles.
+    console_handlers = [
+        h for h in added
+        if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
+    ]
+    assert len(file_handlers) == 1
+    assert len(console_handlers) == 1
+
+
+def test_level_follows_debug_flag(tmp_path, monkeypatch, clean_root_logger):
+    from utils.log_setup import configure_app_logging
+
+    monkeypatch.chdir(tmp_path)
+    configure_app_logging(debug=True, app_version="9.9.9")
+    assert clean_root_logger.level == logging.DEBUG
+
+
+def test_level_info_when_not_debug(tmp_path, monkeypatch, clean_root_logger):
+    from utils.log_setup import configure_app_logging
+
+    monkeypatch.chdir(tmp_path)
+    configure_app_logging(debug=False, app_version="9.9.9")
+    assert clean_root_logger.level == logging.INFO
+
+
+def test_falls_back_to_documents_when_cwd_not_writable(tmp_path, monkeypatch, clean_root_logger):
+    from utils import log_setup
+
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(log_setup.os, "access", lambda *a, **k: False)
+    monkeypatch.setattr(log_setup.os.path, "expanduser", lambda p: str(fake_home))
+
+    path = log_setup.configure_app_logging(debug=False, app_version="9.9.9")
+
+    expected_root = fake_home / "Documents" / "OpenWater Test" / "app-logs"
+    assert Path(path).parent == expected_root.resolve()
+    assert Path(path).is_file()
+
+
+def test_banner_and_log_lines_reach_the_file(tmp_path, monkeypatch, clean_root_logger):
+    from utils.log_setup import configure_app_logging
+
+    monkeypatch.chdir(tmp_path)
+    path = configure_app_logging(debug=False, app_version="9.9.9")
+    logging.getLogger("ow-testapp").info("hello from a module logger")
+
+    # Flush handlers so the assertion reads complete content.
+    for h in clean_root_logger.handlers:
+        h.flush()
+    contents = Path(path).read_text(encoding="utf-8")
+
+    assert "OpenMOTION Test App 9.9.9 starting" in contents
+    assert "hello from a module logger" in contents

--- a/utils/log_setup.py
+++ b/utils/log_setup.py
@@ -1,0 +1,77 @@
+"""Application logging setup for the OpenMOTION test app.
+
+Mirrors the bloodflow app's strategy: every launch writes a timestamped log
+file under ``<root>/app-logs/`` while also echoing to the console. Configures
+the *root* logger so every module logger (``ow-testapp``, ``openmotion.sdk.*``,
+``__main__``, ...) is captured in one file.
+
+Kept free of PyQt imports so it can be unit-tested without launching Qt.
+"""
+import datetime
+import logging
+import os
+
+# SDK loggers that emit one line per USB packet / telemetry tick. Pinned to
+# INFO even in --debug so they don't drown the log.
+_NOISY_SDK_LOGGERS = (
+    "openmotion.sdk.CommInterface",
+    "openmotion.sdk.ConsoleTelemetry",
+    "openmotion.sdk.UARTPACKET",
+    "openmotion.sdk.Sensor",
+)
+
+
+def resolve_log_root() -> str:
+    """Directory under which ``app-logs/`` should live.
+
+    The test app has no ``dataDirectory`` config, so use the current working
+    directory when it is writable, otherwise fall back to
+    ``~/Documents/OpenWater Test`` (e.g. a launch where cwd is read-only).
+    """
+    candidate = os.getcwd()
+    if os.access(candidate, os.W_OK):
+        return candidate
+    return os.path.join(os.path.expanduser("~"), "Documents", "OpenWater Test")
+
+
+def configure_app_logging(debug: bool, app_version: str = "") -> str:
+    """Attach console + timestamped file handlers to the root logger.
+
+    The file lands at ``<root>/app-logs/ow-testapp-<YYYYMMDD_HHMMSS>.log``.
+    Returns the absolute path to that log file.
+    """
+    level = logging.DEBUG if debug else logging.INFO
+    formatter = logging.Formatter(
+        "%(asctime)s - %(levelname)s - %(name)s - %(message)s"
+    )
+
+    data_dir = resolve_log_root()
+    run_dir = os.path.join(data_dir, "app-logs")
+    os.makedirs(run_dir, exist_ok=True)
+    ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    logfile_path = os.path.join(run_dir, f"ow-testapp-{ts}.log")
+
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(level)
+    console_handler.setFormatter(formatter)
+
+    file_handler = logging.FileHandler(logfile_path, mode="w", encoding="utf-8")
+    file_handler.setLevel(level)
+    file_handler.setFormatter(formatter)
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(level)
+    root_logger.addHandler(console_handler)
+    root_logger.addHandler(file_handler)
+
+    if debug:
+        for noisy in _NOISY_SDK_LOGGERS:
+            logging.getLogger(noisy).setLevel(logging.INFO)
+
+    root_logger.info("=" * 64)
+    root_logger.info("OpenMOTION Test App %s starting", app_version)
+    root_logger.info("Log file:       %s", logfile_path)
+    root_logger.info("Data directory: %s", data_dir)
+    root_logger.info("=" * 64)
+
+    return logfile_path


### PR DESCRIPTION
Promotes `next` to `main` for release.

## Included changes

- **#37 — fix: refresh odometer reading after reset** (Console page). The Reset Odometer button now re-queries the console so the panel reflects the cleared counters immediately. Hand-verified on hardware (17.7 h / 223,573 → 0 / 0).
- **#40 — feat: persist app logs to `app-logs/` on every launch.** New `utils/log_setup.py` writes a timestamped `app-logs/ow-testapp-<ts>.log` capturing app + SDK logs; adds the packaged-build stdout/stderr guard; first unit tests in the repo (6 passing). Verified on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)