### PR TITLE
Release: test-app next → main (1.4.0)

### DIFF
--- a/components/IMUWidget.qml
+++ b/components/IMUWidget.qml
@@ -2,8 +2,8 @@ import QtQuick 6.0
 import QtQuick.Controls 6.0
 
 Rectangle {
-    width: 160
-    height: 160
+    width: 120
+    height: 120
     color: "transparent"
 
     // === Properties for IMU data ===
@@ -15,12 +15,12 @@ Rectangle {
 
     // === Border Circle ===
     Rectangle {
-        width: 140
-        height: 140
-        radius: 70
+        width: 105
+        height: 105
+        radius: 52.5
         anchors.centerIn: parent
         border.color: "#D0D3D4"
-        border.width: 4
+        border.width: 3
         color: "transparent"
     }
 
@@ -31,7 +31,7 @@ Rectangle {
 
         Text {
             text: mode
-            font.pixelSize: 16
+            font.pixelSize: 12
             font.bold: true
             color: "#2C3E50"
             horizontalAlignment: Text.AlignHCenter
@@ -40,21 +40,21 @@ Rectangle {
 
         Text {
             text: "X: " + xVal
-            font.pixelSize: 14
+            font.pixelSize: 11
             color: "#3498DB"
             anchors.horizontalCenter: parent.horizontalCenter
         }
 
         Text {
             text: "Y: " + yVal
-            font.pixelSize: 14
+            font.pixelSize: 11
             color: "#27AE60"
             anchors.horizontalCenter: parent.horizontalCenter
         }
 
         Text {
             text: "Z: " + zVal
-            font.pixelSize: 14
+            font.pixelSize: 11
             color: "#E67E22"
             anchors.horizontalCenter: parent.horizontalCenter
         }

--- a/components/TemperatureWidget.qml
+++ b/components/TemperatureWidget.qml
@@ -3,8 +3,8 @@ import QtQuick.Controls 6.0
 import QtQuick.Shapes 6.0
 
 Rectangle {
-    width: 160
-    height: 160
+    width: 120
+    height: 120
     color: "transparent"
 
     property real temperature: 0    // Starting temperature
@@ -18,8 +18,8 @@ Rectangle {
     Canvas {
         id: arcCanvas
         anchors.centerIn: parent
-        width: 140
-        height: 140
+        width: 105
+        height: 105
 
         onPaint: {
             var ctx = getContext("2d")
@@ -27,16 +27,16 @@ Rectangle {
 
             // Background Arc (Light Gray)
             ctx.beginPath()
-            ctx.arc(width / 2, height / 2, 60, Math.PI * 0.75, Math.PI * 2.25, false)
-            ctx.lineWidth = 10
+            ctx.arc(width / 2, height / 2, 45, Math.PI * 0.75, Math.PI * 2.25, false)
+            ctx.lineWidth = 7.5
             ctx.strokeStyle = "#D0D3D4"
             ctx.stroke()
 
             // Foreground Arc (Dynamic Color)
             var angle = (temperature / 70) * 270  // Correct scaling for 0-70°C range
             ctx.beginPath()
-            ctx.arc(width / 2, height / 2, 60, Math.PI * 0.75, Math.PI * (0.75 + (angle / 180)), false)
-            ctx.lineWidth = 10
+            ctx.arc(width / 2, height / 2, 45, Math.PI * 0.75, Math.PI * (0.75 + (angle / 180)), false)
+            ctx.lineWidth = 7.5
             ctx.strokeStyle = gaugeColor
             ctx.stroke()
         }
@@ -51,7 +51,7 @@ Rectangle {
     Text {
         text: temperature.toFixed(0) + "°C"
         anchors.centerIn: parent
-        font.pixelSize: 24
+        font.pixelSize: 18
         color: "#4B4B4B"
         font.weight: Font.Bold
     }
@@ -62,9 +62,9 @@ Rectangle {
         anchors {
             top: parent.bottom
             horizontalCenter: parent.horizontalCenter
-            topMargin: 5
+            topMargin: 4
         }
-        font.pixelSize: 16
+        font.pixelSize: 12
         color: "#BDC3C7"
         font.weight: Font.Medium
     }

--- a/docs/superpowers/specs/2026-06-17-tec-trip-configurator-design.md
+++ b/docs/superpowers/specs/2026-06-17-tec-trip-configurator-design.md
@@ -1,0 +1,105 @@
+# TEC Trip Temperature Configurator — Design
+
+**Date:** 2026-06-17
+**Repo:** openmotion-test-app
+**Status:** Approved
+
+## Goal
+
+Give the user a friendly control to read and change the console's **TEC trip
+temperature** (the over-temperature threshold at which the TEC comparator trips).
+The control lives in the **TEC CTRL** tab of the Demo screen.
+
+## Background
+
+The console firmware stores the trip temperature as a `TEC_TRIP` key (a float
+°C, e.g. `40.0`) inside its **user-config JSON**. On boot/config-apply the
+firmware parses `TEC_TRIP`, converts temperature → thermistor resistance →
+comparator trip voltage (`apply_tec_trip_setting` in
+`openmotion-console-fw/Core/Src/main.c`).
+
+The SDK already exposes the config: `console.read_config()` /
+`console.write_config(cfg)`, where the config object supports `.get(key)`,
+`.set(key, value)`, and `.json_data`.
+
+### Existing (broken) state — not used by this design
+
+- `pages/Console.qml` has a `TEC_TRIP` numeric field, but its container is
+  `visible: false` and it is anchored on top of the Odometer box (it overlaps
+  the Uptime/Laser-pulses readout if un-hidden). Its `onAccepted` calls
+  `setTecTrip()`, which delegates to `set_ta_gain_resistor()` — i.e. it sets the
+  **TA gain resistor**, not the trip temperature. `queryTecTripValue()` is a stub
+  returning 0. **This block is left hidden and untouched; flagged as dead code to
+  remove later.**
+
+## Design
+
+### Backend — `motion_connector.py`
+
+1. **`queryTecTripValue()`** — replace the stub. On a daemon worker thread
+   (mirrors `_do_read_user_config`), under `_console_mutex`:
+   - `config = motion_interface.console.read_config()`
+   - `set_tec_trip_value(int(round(float(config.get("TEC_TRIP") or 0))))`
+   - On `None`/exception: log and leave the current value unchanged (no crash).
+
+2. **`setTecTrip(res: int) -> bool`** — rewrite as a **read-modify-write** of the
+   user config, keeping the synchronous `@pyqtSlot(int, result=bool)` signature
+   QML depends on. Under `_console_mutex`:
+   - `config = console.read_config()` → if `None`, emit `tecTripSetFailed`, return `False`
+   - `config.set("TEC_TRIP", res)`
+   - `updated = console.write_config(config)` → if `None`, emit `tecTripSetFailed`, return `False`
+   - On success: `set_tec_trip_value(res)`, return `True`
+
+   Read-modify-write preserves all sibling keys (`OPT_GAIN`, `OPT_THRESH`,
+   `EE_GAIN`, `EE_THRESH`). We deliberately do **not** route through
+   `setUserConfig`/`_do_write_user_config`, which drops OPT/EE keys when their
+   thresholds are 0.
+
+3. **New signal** `tecTripSetFailed = pyqtSignal(str)` — emitted on read/write
+   failure, replacing the confusing reuse of `taGainSetFailed` for TEC errors.
+
+`set_ta_gain_resistor` and the TA-gain UI are untouched.
+
+### Frontend — `pages/Demo.qml`, `pageTec` (TEC CTRL tab)
+
+The `pageTec` 4-column `GridLayout` currently has:
+- Row 0: TEC Status cards (Setpoint °C / Current / Voltage) + Temperature indicator
+- Row 1: "TEC Temperature" label + "DAC Setpoint (V)" field + "Update Setpoint" button
+
+Add **Row 2**, mirroring the Row 1 pattern:
+- Col 0: label `"TEC Trip (°C)"`
+- Cols 1–3: caption `"Trip Temp (°C)"` + a `TextField`
+  (`IntValidator { bottom: 0; top: 125 }`, `enabled: consoleConnected`, text
+  bound to `MOTIONInterface.tecTripValue`) + a `"Set Trip"` `ActionButton`.
+
+Behavior:
+- Button / `onAccepted`: parse + clamp 0–125, call `MOTIONInterface.setTecTrip(v)`.
+- Add `MOTIONInterface.queryTecTripValue()` to `pageTec`'s existing
+  `Component.onCompleted` (next to `tec_status()`), so opening the tab reads the
+  live trip temperature.
+- Add `Connections` handlers: `onTecTripValueChanged` (refresh the field text)
+  and `onTecTripSetFailed(msg)` (surface the error, e.g. inline red text with a
+  brief auto-clear timer).
+
+## Value semantics
+
+- Integer °C, range 0–125 (matches existing validator intent).
+- Stored to config as the integer the user typed; firmware parses with `strtod`,
+  so `40` and `40.0` are equivalent.
+
+## Testing / verification
+
+- **Primary (manual):** launch the test app with the console attached, open Demo
+  → TEC CTRL, confirm the field renders cleanly (no overlap), pre-populates with
+  the device's current `TEC_TRIP`, accepts a 0–125 value, and the firmware debug
+  log shows `TEC_TRIP found: <n>` after writing. Confirm OPT/EE keys are
+  preserved by re-reading the config.
+- **Optional (unit):** a `tests/` test mocking `console.read_config` /
+  `write_config` to assert `setTecTrip` does read-modify-write and preserves
+  sibling keys, and `queryTecTripValue` parses `TEC_TRIP`. No existing unit-test
+  seam, so this would be the first of its kind.
+
+## Out of scope
+
+- The hidden `Console.qml` `TEC_TRIP` block (left as dead code; remove later).
+- Float-precision trip values, per-channel trip, or any firmware changes.

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -929,6 +929,8 @@ class MOTIONConnector(QObject):
     sensorDeviceInfoReceived = pyqtSignal(str, str)
     # Target-aware variant for pages that need both left/right info simultaneously
     sensorDeviceInfoReceivedEx = pyqtSignal(str, str, str)
+    sensorSerialNumberReceived = pyqtSignal(str, str)        # (target, serial) serial "" if unprogrammed
+    sensorSerialNumberWritten = pyqtSignal(str, bool, str)   # (target, ok, message)
     temperatureSensorUpdated = pyqtSignal(float)  # (imu_temp)
     accelerometerSensorUpdated = pyqtSignal(int, int, int)  # (imu_accel)
     gyroscopeSensorUpdated = pyqtSignal(int, int, int)  # (imu_accel)
@@ -2192,6 +2194,8 @@ class MOTIONConnector(QObject):
                     # Emit signal for async UI update
                     self.sensorDeviceInfoReceived.emit(fw_version, device_id)
                     self.sensorDeviceInfoReceivedEx.emit(target, fw_version, device_id)
+                    serial = getattr(motion_interface, sensor_tag).read_serial_number() or ""
+                    self.sensorSerialNumberReceived.emit(target, serial)
                     logger.info(
                         f"Sensor Device Info - Firmware: {fw_version}, Device ID: {device_id}"
                     )
@@ -2202,6 +2206,54 @@ class MOTIONConnector(QObject):
                 return
         except Exception as e:
             logger.error(f"Error querying device info: {e}")
+
+    @pyqtSlot(str, result=str)
+    def readSensorSerialNumber(self, target: str) -> str:
+        """Read the selected sensor's serial; emit (target, serial); return "" if unprogrammed."""
+        if target not in ("left", "right"):
+            logger.error(f"Invalid target for sensor serial read: {target}")
+            return ""
+        mutex = self._get_sensor_mutex(target)
+        mutex.lock()
+        try:
+            serial = getattr(motion_interface, target).read_serial_number() or ""
+            self.sensorSerialNumberReceived.emit(target, serial)
+            return serial
+        except Exception as e:
+            logger.error(f"Error reading sensor serial number: {e}")
+            self.sensorSerialNumberReceived.emit(target, "")
+            return ""
+        finally:
+            mutex.unlock()
+
+    @pyqtSlot(str, str, bool, result=bool)
+    def writeSensorSerialNumber(self, target: str, serial: str, force: bool) -> bool:
+        """Write the selected sensor's serial; emit (target, ok, message)."""
+        if target not in ("left", "right"):
+            logger.error(f"Invalid target for sensor serial write: {target}")
+            self.sensorSerialNumberWritten.emit(target, False, "Invalid sensor target")
+            return False
+        mutex = self._get_sensor_mutex(target)
+        mutex.lock()
+        try:
+            ok = getattr(motion_interface, target).write_serial_number(serial, force=force)
+            if ok:
+                msg = f"Serial '{serial}' written"
+                logger.info(msg)
+                self.sensorSerialNumberWritten.emit(target, True, msg)
+                self.sensorSerialNumberReceived.emit(target, serial)
+                return True
+            msg = "Write failed (already programmed? use overwrite, or check input)"
+            logger.error(msg)
+            self.sensorSerialNumberWritten.emit(target, False, msg)
+            return False
+        except Exception as e:
+            msg = f"Error writing serial: {e}"
+            logger.error(msg)
+            self.sensorSerialNumberWritten.emit(target, False, msg)
+            return False
+        finally:
+            mutex.unlock()
 
     @pyqtSlot()
     def queryConsoleInfo(self):

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -924,6 +924,8 @@ class MOTIONConnector(QObject):
     signalDataReceived = pyqtSignal(str, str)  # (descriptor, data)
 
     consoleDeviceInfoReceived = pyqtSignal(str, str, str)
+    consoleSerialNumberReceived = pyqtSignal(str)        # current serial ("" if unprogrammed)
+    consoleSerialNumberWritten = pyqtSignal(bool, str)   # (ok, message)
     sensorDeviceInfoReceived = pyqtSignal(str, str)
     # Target-aware variant for pages that need both left/right info simultaneously
     sensorDeviceInfoReceivedEx = pyqtSignal(str, str, str)
@@ -2211,12 +2213,54 @@ class MOTIONConnector(QObject):
             hw_id = motion_interface.console.get_hardware_id()
             device_id = base58.b58encode(bytes.fromhex(hw_id)).decode()
             board_id = motion_interface.console.read_board_id()
+            serial = motion_interface.console.read_serial_number() or ""
             self.consoleDeviceInfoReceived.emit(fw_version, device_id, str(board_id))
+            self.consoleSerialNumberReceived.emit(serial)
             logger.info(
                 f"Console Device Info - Firmware: {fw_version}, Device ID: {device_id}, Board ID: {board_id}"
             )
         except Exception as e:
             logger.error(f"Error querying device info: {e}")
+        finally:
+            self._console_mutex.unlock()
+
+    @pyqtSlot(result=str)
+    def readConsoleSerialNumber(self) -> str:
+        """Read the console serial; emit it and return it ("" if unprogrammed)."""
+        self._console_mutex.lock()
+        try:
+            serial = motion_interface.console.read_serial_number()
+            serial = serial or ""
+            self.consoleSerialNumberReceived.emit(serial)
+            return serial
+        except Exception as e:
+            logger.error(f"Error reading console serial number: {e}")
+            self.consoleSerialNumberReceived.emit("")
+            return ""
+        finally:
+            self._console_mutex.unlock()
+
+    @pyqtSlot(str, bool, result=bool)
+    def writeConsoleSerialNumber(self, serial: str, force: bool) -> bool:
+        """Write the console serial; emit (ok, message)."""
+        self._console_mutex.lock()
+        try:
+            ok = motion_interface.console.write_serial_number(serial, force=force)
+            if ok:
+                msg = f"Serial '{serial}' written"
+                logger.info(msg)
+                self.consoleSerialNumberWritten.emit(True, msg)
+                self.consoleSerialNumberReceived.emit(serial)
+                return True
+            msg = "Write failed (already programmed? use overwrite, or check input)"
+            logger.error(msg)
+            self.consoleSerialNumberWritten.emit(False, msg)
+            return False
+        except Exception as e:
+            msg = f"Error writing serial: {e}"
+            logger.error(msg)
+            self.consoleSerialNumberWritten.emit(False, msg)
+            return False
         finally:
             self._console_mutex.unlock()
 

--- a/motion_connector.py
+++ b/motion_connector.py
@@ -1012,6 +1012,7 @@ class MOTIONConnector(QObject):
 
     tecTripValueChanged = pyqtSignal()
     taGainSetFailed = pyqtSignal(str)
+    tecTripSetFailed = pyqtSignal(str)  # error message when reading/writing TEC_TRIP fails
 
     userConfigLoaded = pyqtSignal(
         float, float, float, float, float
@@ -3260,41 +3261,62 @@ class MOTIONConnector(QObject):
 
     @pyqtSlot()
     def queryTecTripValue(self):
-        """
-        Query current TEC trip value from the console module.
-        Currently stubbed; prefer implementing actual SDK call.
-        """
-        # TODO: replace stub with actual SDK query when available
-        self.set_tec_trip_value(0)
+        """Read the current TEC trip temperature (°C) from the console's user
+        config and publish it via tecTripValue. Runs on a worker thread so the
+        UI stays responsive."""
+        import threading
+
+        threading.Thread(target=self._do_query_tec_trip, daemon=True).start()
+
+    def _do_query_tec_trip(self):
+        self._console_mutex.lock()
+        try:
+            config = motion_interface.console.read_config()
+            if config is None:
+                logger.error("Failed to read user config for TEC_TRIP query")
+                return
+            value = int(round(float(config.get("TEC_TRIP") or 0)))
+            logger.info(f"TEC_TRIP read from device: {value} °C")
+            self.set_tec_trip_value(value)
+        except Exception as e:
+            logger.error(f"Error querying TEC trip temperature: {e}")
+        finally:
+            self._console_mutex.unlock()
 
     @pyqtSlot(int, result=bool)
     def setTecTrip(self, res: int) -> bool:
-        """Set TEC trip point.
+        """Set the TEC trip temperature (°C).
 
-        Calls the underlying SDK method `set_ta_gain_resistor` (TA resistor
-        setting used for TEC trip) and returns True on success.
+        Reads the console's user config, updates only the ``TEC_TRIP`` key
+        (preserving every other key), and writes it back. Returns True on
+        success; emits ``tecTripSetFailed(msg)`` on failure.
         """
         self._console_mutex.lock()
         try:
-            # Delegate to console module
-            result = motion_interface.console.set_ta_gain_resistor(res)
-            if result:
-                logger.info(f"TA gain resistor set to {res} ohms")
-                return True
-            else:
-                msg = f"Failed to set TA gain resistor to {res} ohms"
+            config = motion_interface.console.read_config()
+            if config is None:
+                msg = "Failed to read user config before setting TEC_TRIP"
                 logger.error(msg)
-                self.taGainSetFailed.emit(msg)
+                self.tecTripSetFailed.emit(msg)
                 return False
-        except ValueError as ve:
-            msg = f"Invalid TA gain value or console not connected: {ve}"
-            logger.error(msg)
-            self.taGainSetFailed.emit(msg)
-            return False
+
+            # Read-modify-write: only touch TEC_TRIP, leave OPT_*/EE_* intact.
+            config.set("TEC_TRIP", res)
+
+            updated = motion_interface.console.write_config(config)
+            if updated is None:
+                msg = f"Failed to write TEC_TRIP={res} °C to device"
+                logger.error(msg)
+                self.tecTripSetFailed.emit(msg)
+                return False
+
+            logger.info(f"TEC trip temperature set to {res} °C")
+            self.set_tec_trip_value(res)
+            return True
         except Exception as e:
-            msg = f"Error setting TA gain resistor: {e}"
+            msg = f"Error setting TEC trip temperature: {e}"
             logger.error(msg)
-            self.taGainSetFailed.emit(msg)
+            self.tecTripSetFailed.emit(msg)
             return False
         finally:
             self._console_mutex.unlock()

--- a/pages/Console.qml
+++ b/pages/Console.qml
@@ -188,15 +188,17 @@ Rectangle {
         }
 
         function onConsoleSerialNumberReceived(serial) {
-            serialCurrent.programmed = (serial.length > 0)
-            serialCurrent.text = serial.length > 0 ? ("Current: " + serial)
-                                                   : "Current: not programmed"
+            consoleSerialValue.programmed = (serial.length > 0)
+            consoleSerialValue.text = serial.length > 0 ? serial : "not programmed"
         }
         function onConsoleSerialNumberWritten(ok, message) {
-            serialStatus.text = message
-            serialStatus.color = ok ? "lightgreen" : "red"
-            clearSerialStatusTimer.restart()
-            if (ok) serialInput.text = ""
+            consoleSerialStatus.text = message
+            consoleSerialStatus.color = ok ? "lightgreen" : "red"
+            clearConsoleSerialStatusTimer.restart()
+            if (ok) {
+                consoleSerialInput.text = ""
+                consoleSerialRow.editing = false
+            }
         }
     }
 
@@ -1350,113 +1352,6 @@ Rectangle {
                         }
                     }
 
-                    // Console Serial Number
-                    Rectangle {
-                        width: 650
-                        height: 160
-                        radius: 8
-                        color: "#1E1E20"
-                        border.color: "#3E4E6F"
-                        border.width: 2
-                        enabled: MOTIONInterface.consoleConnected
-
-                        Text {
-                            id: serialTitle
-                            text: "Console Serial Number"
-                            color: "#BDC3C7"
-                            font.pixelSize: 16
-                            font.bold: true
-                            anchors.top: parent.top
-                            anchors.topMargin: 12
-                            anchors.horizontalCenter: parent.horizontalCenter
-                        }
-
-                        ColumnLayout {
-                            anchors.top: serialTitle.bottom
-                            anchors.topMargin: 12
-                            anchors.left: parent.left
-                            anchors.right: parent.right
-                            anchors.margins: 12
-                            spacing: 10
-
-                            Text {
-                                id: serialCurrent
-                                property bool programmed: false
-                                Layout.fillWidth: true
-                                text: "Current: not programmed"
-                                color: "#3498DB"
-                                font.pixelSize: 13
-                            }
-
-                            RowLayout {
-                                Layout.fillWidth: true
-                                spacing: 12
-
-                                RegularExpressionValidator {
-                                    id: serialValidator
-                                    regularExpression: /^[A-Z0-9]{0,24}$/
-                                }
-
-                                TextField {
-                                    id: serialInput
-                                    Layout.fillWidth: true
-                                    Layout.preferredHeight: 32
-                                    placeholderText: "e.g. QWW04Q10003"
-                                    maximumLength: 24
-                                    validator: serialValidator
-                                    inputMethodHints: Qt.ImhUppercaseOnly
-                                }
-
-                                Button {
-                                    id: serialWriteButton
-                                    text: "Write"
-                                    Layout.preferredWidth: 100
-                                    Layout.preferredHeight: 40
-                                    hoverEnabled: true
-                                    enabled: MOTIONInterface.consoleConnected &&
-                                             serialInput.acceptableInput && serialInput.text.length > 0
-
-                                    contentItem: Text {
-                                        text: parent.text
-                                        color: parent.enabled ? "#BDC3C7" : "#7F8C8D"
-                                        horizontalAlignment: Text.AlignHCenter
-                                        verticalAlignment: Text.AlignVCenter
-                                    }
-                                    background: Rectangle {
-                                        color: parent.hovered ? "#4A90E2" : "#3A3F4B"
-                                        radius: 4
-                                        border.color: parent.hovered ? "#FFFFFF" : "#BDC3C7"
-                                    }
-
-                                    onClicked: {
-                                        if (serialCurrent.programmed) {
-                                            serialConfirmDialog.pending = serialInput.text
-                                            serialConfirmDialog.open()
-                                        } else {
-                                            MOTIONInterface.writeConsoleSerialNumber(serialInput.text, false)
-                                        }
-                                    }
-                                }
-                            }
-
-                            Text {
-                                id: serialStatus
-                                text: ""
-                                color: "#BDC3C7"
-                                font.pixelSize: 12
-                                Layout.fillWidth: true
-                                horizontalAlignment: Text.AlignHCenter
-                            }
-
-                            Timer {
-                                id: clearSerialStatusTimer
-                                interval: 3000
-                                running: false
-                                repeat: false
-                                onTriggered: serialStatus.text = ""
-                            }
-                        }
-                    }
                 }
 
                 // Large Third Column
@@ -1543,6 +1438,132 @@ Rectangle {
                             spacing: 8
                             Text { text: "Device ID:"; color: "#BDC3C7"; font.pixelSize: 14 }
                             Text { text: deviceId; color: "#3498DB"; font.pixelSize: 14 }
+                        }
+
+                        // Serial Number — matches the Device ID row, with a pencil to edit
+                        ColumnLayout {
+                            id: consoleSerialRow
+                            property bool editing: false
+                            Layout.fillWidth: true
+                            spacing: 6
+
+                            // Display mode: label + value + pencil
+                            RowLayout {
+                                spacing: 8
+                                visible: !consoleSerialRow.editing
+
+                                Text { text: "Serial Number:"; color: "#BDC3C7"; font.pixelSize: 14 }
+                                Text {
+                                    id: consoleSerialValue
+                                    property bool programmed: false
+                                    text: "not programmed"
+                                    color: "#3498DB"
+                                    font.pixelSize: 14
+                                }
+
+                                // Pencil edit affordance
+                                Text {
+                                    id: consoleSerialEditIcon
+                                    text: "✎"  // pencil
+                                    font.pixelSize: 16
+                                    font.family: iconFont.name
+                                    color: consoleSerialPencilMouse.containsMouse ? "#FFFFFF" : "#BDC3C7"
+                                    visible: MOTIONInterface.consoleConnected
+
+                                    MouseArea {
+                                        id: consoleSerialPencilMouse
+                                        anchors.fill: parent
+                                        hoverEnabled: true
+                                        cursorShape: Qt.PointingHandCursor
+                                        onClicked: consoleSerialEditConfirmDialog.open()
+                                    }
+                                    ToolTip.visible: consoleSerialPencilMouse.containsMouse
+                                    ToolTip.text: "Edit serial number"
+                                    ToolTip.delay: 400
+                                }
+                            }
+
+                            // Edit mode: revealed only after the user confirms via the pencil
+                            RowLayout {
+                                spacing: 8
+                                visible: consoleSerialRow.editing
+
+                                Text { text: "Serial Number:"; color: "#BDC3C7"; font.pixelSize: 14 }
+
+                                RegularExpressionValidator {
+                                    id: consoleSerialValidator
+                                    regularExpression: /^[A-Z0-9]{0,24}$/
+                                }
+
+                                TextField {
+                                    id: consoleSerialInput
+                                    Layout.preferredWidth: 180
+                                    Layout.preferredHeight: 28
+                                    placeholderText: "e.g. QWW04Q10003"
+                                    maximumLength: 24
+                                    validator: consoleSerialValidator
+                                    inputMethodHints: Qt.ImhUppercaseOnly
+                                }
+
+                                Button {
+                                    text: "Save"
+                                    Layout.preferredWidth: 70
+                                    Layout.preferredHeight: 28
+                                    hoverEnabled: true
+                                    enabled: consoleSerialInput.acceptableInput && consoleSerialInput.text.length > 0
+                                    contentItem: Text {
+                                        text: parent.text
+                                        color: parent.enabled ? "#BDC3C7" : "#7F8C8D"
+                                        horizontalAlignment: Text.AlignHCenter
+                                        verticalAlignment: Text.AlignVCenter
+                                    }
+                                    background: Rectangle {
+                                        color: parent.hovered ? "#4A90E2" : "#3A3F4B"
+                                        radius: 4
+                                        border.color: parent.hovered ? "#FFFFFF" : "#BDC3C7"
+                                    }
+                                    onClicked: MOTIONInterface.writeConsoleSerialNumber(consoleSerialInput.text, true)
+                                }
+
+                                Button {
+                                    text: "Cancel"
+                                    Layout.preferredWidth: 70
+                                    Layout.preferredHeight: 28
+                                    hoverEnabled: true
+                                    contentItem: Text {
+                                        text: parent.text
+                                        color: "#BDC3C7"
+                                        horizontalAlignment: Text.AlignHCenter
+                                        verticalAlignment: Text.AlignVCenter
+                                    }
+                                    background: Rectangle {
+                                        color: parent.hovered ? "#4A90E2" : "#3A3F4B"
+                                        radius: 4
+                                        border.color: "#BDC3C7"
+                                    }
+                                    onClicked: {
+                                        consoleSerialRow.editing = false
+                                        consoleSerialInput.text = ""
+                                    }
+                                }
+                            }
+
+                            // Write result status (auto-clears)
+                            Text {
+                                id: consoleSerialStatus
+                                text: ""
+                                visible: text.length > 0
+                                color: "#BDC3C7"
+                                font.pixelSize: 12
+                            }
+
+                            Timer {
+                                id: clearConsoleSerialStatusTimer
+                                interval: 3000
+                                running: false
+                                repeat: false
+                                onTriggered: consoleSerialStatus.text = ""
+                            }
                         }
 
                         // Board Rev ID (Smaller Text)
@@ -1776,17 +1797,15 @@ Rectangle {
         }
     }
 
-    // Confirmation for overwriting an already-programmed serial number
+    // Confirmation before editing the console serial number (opened by the pencil)
     Dialog {
-        id: serialConfirmDialog
-        title: "Overwrite Serial Number"
-        width: 480
-        height: 220
+        id: consoleSerialEditConfirmDialog
+        title: "Change Serial Number"
+        width: 440
+        height: 190
         modal: true
         x: (parent.width - width) / 2
         y: (parent.height - height) / 2
-
-        property string pending: ""
 
         ColumnLayout {
             anchors.fill: parent
@@ -1798,9 +1817,7 @@ Rectangle {
                 color: "#E67E22"
                 font.pixelSize: 14
                 font.bold: true
-                text: "This console already has a serial number (" +
-                      serialCurrent.text.replace("Current: ", "") +
-                      "). Overwrite it with '" + serialConfirmDialog.pending + "'?"
+                text: "Are you sure you want to change this console's serial number?"
             }
 
             RowLayout {
@@ -1813,17 +1830,19 @@ Rectangle {
                     Layout.preferredHeight: 32
                     background: Rectangle { color: parent.hovered ? "#4A90E2" : "#3A3F4B"; radius: 4; border.color: "#BDC3C7" }
                     contentItem: Text { text: parent.text; color: "#BDC3C7"; horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter }
-                    onClicked: serialConfirmDialog.close()
+                    onClicked: consoleSerialEditConfirmDialog.close()
                 }
                 Button {
-                    text: "Overwrite"
-                    Layout.preferredWidth: 120
+                    text: "Yes, change it"
+                    Layout.preferredWidth: 140
                     Layout.preferredHeight: 32
                     background: Rectangle { color: parent.hovered ? "#E67E22" : "#3A3F4B"; radius: 4; border.color: "#E67E22" }
                     contentItem: Text { text: parent.text; color: "#E67E22"; horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter; font.bold: true }
                     onClicked: {
-                        serialConfirmDialog.close()
-                        MOTIONInterface.writeConsoleSerialNumber(serialConfirmDialog.pending, true)
+                        consoleSerialEditConfirmDialog.close()
+                        consoleSerialInput.text = ""
+                        consoleSerialRow.editing = true
+                        consoleSerialInput.forceActiveFocus()
                     }
                 }
             }

--- a/pages/Console.qml
+++ b/pages/Console.qml
@@ -192,12 +192,10 @@ Rectangle {
             consoleSerialValue.text = serial.length > 0 ? serial : "not programmed"
         }
         function onConsoleSerialNumberWritten(ok, message) {
-            consoleSerialStatus.text = message
-            consoleSerialStatus.color = ok ? "lightgreen" : "red"
-            clearConsoleSerialStatusTimer.restart()
             if (ok) {
-                consoleSerialInput.text = ""
-                consoleSerialRow.editing = false
+                consoleSerialEditDialog.close()
+            } else {
+                consoleSerialEditStatus.text = message
             }
         }
     }
@@ -1440,129 +1438,38 @@ Rectangle {
                             Text { text: deviceId; color: "#3498DB"; font.pixelSize: 14 }
                         }
 
-                        // Serial Number — matches the Device ID row, with a pencil to edit
-                        ColumnLayout {
-                            id: consoleSerialRow
-                            property bool editing: false
-                            Layout.fillWidth: true
-                            spacing: 6
+                        // Serial Number — matches the Device ID row; pencil opens an edit modal
+                        RowLayout {
+                            spacing: 8
 
-                            // Display mode: label + value + pencil
-                            RowLayout {
-                                spacing: 8
-                                visible: !consoleSerialRow.editing
-
-                                Text { text: "Serial Number:"; color: "#BDC3C7"; font.pixelSize: 14 }
-                                Text {
-                                    id: consoleSerialValue
-                                    property bool programmed: false
-                                    text: "not programmed"
-                                    color: "#3498DB"
-                                    font.pixelSize: 14
-                                }
-
-                                // Pencil edit affordance
-                                Text {
-                                    id: consoleSerialEditIcon
-                                    text: "✎"  // pencil
-                                    font.pixelSize: 16
-                                    font.family: iconFont.name
-                                    color: consoleSerialPencilMouse.containsMouse ? "#FFFFFF" : "#BDC3C7"
-                                    visible: MOTIONInterface.consoleConnected
-
-                                    MouseArea {
-                                        id: consoleSerialPencilMouse
-                                        anchors.fill: parent
-                                        hoverEnabled: true
-                                        cursorShape: Qt.PointingHandCursor
-                                        onClicked: consoleSerialEditConfirmDialog.open()
-                                    }
-                                    ToolTip.visible: consoleSerialPencilMouse.containsMouse
-                                    ToolTip.text: "Edit serial number"
-                                    ToolTip.delay: 400
-                                }
-                            }
-
-                            // Edit mode: revealed only after the user confirms via the pencil
-                            RowLayout {
-                                spacing: 8
-                                visible: consoleSerialRow.editing
-
-                                Text { text: "Serial Number:"; color: "#BDC3C7"; font.pixelSize: 14 }
-
-                                RegularExpressionValidator {
-                                    id: consoleSerialValidator
-                                    regularExpression: /^[A-Z0-9]{0,24}$/
-                                }
-
-                                TextField {
-                                    id: consoleSerialInput
-                                    Layout.preferredWidth: 180
-                                    Layout.preferredHeight: 28
-                                    placeholderText: "e.g. QWW04Q10003"
-                                    maximumLength: 24
-                                    validator: consoleSerialValidator
-                                    inputMethodHints: Qt.ImhUppercaseOnly
-                                }
-
-                                Button {
-                                    text: "Save"
-                                    Layout.preferredWidth: 70
-                                    Layout.preferredHeight: 28
-                                    hoverEnabled: true
-                                    enabled: consoleSerialInput.acceptableInput && consoleSerialInput.text.length > 0
-                                    contentItem: Text {
-                                        text: parent.text
-                                        color: parent.enabled ? "#BDC3C7" : "#7F8C8D"
-                                        horizontalAlignment: Text.AlignHCenter
-                                        verticalAlignment: Text.AlignVCenter
-                                    }
-                                    background: Rectangle {
-                                        color: parent.hovered ? "#4A90E2" : "#3A3F4B"
-                                        radius: 4
-                                        border.color: parent.hovered ? "#FFFFFF" : "#BDC3C7"
-                                    }
-                                    onClicked: MOTIONInterface.writeConsoleSerialNumber(consoleSerialInput.text, true)
-                                }
-
-                                Button {
-                                    text: "Cancel"
-                                    Layout.preferredWidth: 70
-                                    Layout.preferredHeight: 28
-                                    hoverEnabled: true
-                                    contentItem: Text {
-                                        text: parent.text
-                                        color: "#BDC3C7"
-                                        horizontalAlignment: Text.AlignHCenter
-                                        verticalAlignment: Text.AlignVCenter
-                                    }
-                                    background: Rectangle {
-                                        color: parent.hovered ? "#4A90E2" : "#3A3F4B"
-                                        radius: 4
-                                        border.color: "#BDC3C7"
-                                    }
-                                    onClicked: {
-                                        consoleSerialRow.editing = false
-                                        consoleSerialInput.text = ""
-                                    }
-                                }
-                            }
-
-                            // Write result status (auto-clears)
+                            Text { text: "Serial Number:"; color: "#BDC3C7"; font.pixelSize: 14 }
                             Text {
-                                id: consoleSerialStatus
-                                text: ""
-                                visible: text.length > 0
-                                color: "#BDC3C7"
-                                font.pixelSize: 12
+                                id: consoleSerialValue
+                                property bool programmed: false
+                                text: "not programmed"
+                                color: "#3498DB"
+                                font.pixelSize: 14
                             }
 
-                            Timer {
-                                id: clearConsoleSerialStatusTimer
-                                interval: 3000
-                                running: false
-                                repeat: false
-                                onTriggered: consoleSerialStatus.text = ""
+                            // Pencil opens the edit modal
+                            Text {
+                                id: consoleSerialEditIcon
+                                text: "✎"  // pencil
+                                font.pixelSize: 16
+                                font.family: iconFont.name
+                                color: consoleSerialPencilMouse.containsMouse ? "#FFFFFF" : "#BDC3C7"
+                                visible: MOTIONInterface.consoleConnected
+
+                                MouseArea {
+                                    id: consoleSerialPencilMouse
+                                    anchors.fill: parent
+                                    hoverEnabled: true
+                                    cursorShape: Qt.PointingHandCursor
+                                    onClicked: consoleSerialEditDialog.open()
+                                }
+                                ToolTip.visible: consoleSerialPencilMouse.containsMouse
+                                ToolTip.text: "Edit serial number"
+                                ToolTip.delay: 400
                             }
                         }
 
@@ -1799,19 +1706,25 @@ Rectangle {
         }
     }
 
-    // Confirmation before editing the console serial number (opened by the pencil)
+    // Edit modal: enter a new console serial number (opened by the pencil)
     Dialog {
-        id: consoleSerialEditConfirmDialog
+        id: consoleSerialEditDialog
         title: "Change Serial Number"
         width: 440
-        height: 190
+        height: 240
         modal: true
         x: (parent.width - width) / 2
         y: (parent.height - height) / 2
 
+        onOpened: {
+            consoleSerialInput.text = ""
+            consoleSerialEditStatus.text = ""
+            consoleSerialInput.forceActiveFocus()
+        }
+
         ColumnLayout {
             anchors.fill: parent
-            spacing: 16
+            spacing: 14
 
             Text {
                 Layout.fillWidth: true
@@ -1819,7 +1732,32 @@ Rectangle {
                 color: "#E67E22"
                 font.pixelSize: 14
                 font.bold: true
-                text: "Are you sure you want to change this console's serial number?"
+                text: "Are you sure you want to change this console's serial number? Enter the new value:"
+            }
+
+            RegularExpressionValidator {
+                id: consoleSerialValidator
+                regularExpression: /^[A-Z0-9]{0,24}$/
+            }
+
+            TextField {
+                id: consoleSerialInput
+                Layout.fillWidth: true
+                Layout.preferredHeight: 32
+                placeholderText: "e.g. QWW04Q10003"
+                maximumLength: 24
+                validator: consoleSerialValidator
+                inputMethodHints: Qt.ImhUppercaseOnly
+                onAccepted: if (consoleSerialSaveButton.enabled) consoleSerialSaveButton.clicked()
+            }
+
+            Text {
+                id: consoleSerialEditStatus
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
+                visible: text.length > 0
+                color: "#E74C3C"
+                font.pixelSize: 12
             }
 
             RowLayout {
@@ -1832,20 +1770,17 @@ Rectangle {
                     Layout.preferredHeight: 32
                     background: Rectangle { color: parent.hovered ? "#4A90E2" : "#3A3F4B"; radius: 4; border.color: "#BDC3C7" }
                     contentItem: Text { text: parent.text; color: "#BDC3C7"; horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter }
-                    onClicked: consoleSerialEditConfirmDialog.close()
+                    onClicked: consoleSerialEditDialog.close()
                 }
                 Button {
-                    text: "Yes, change it"
-                    Layout.preferredWidth: 140
+                    id: consoleSerialSaveButton
+                    text: "Save"
+                    Layout.preferredWidth: 120
                     Layout.preferredHeight: 32
-                    background: Rectangle { color: parent.hovered ? "#E67E22" : "#3A3F4B"; radius: 4; border.color: "#E67E22" }
-                    contentItem: Text { text: parent.text; color: "#E67E22"; horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter; font.bold: true }
-                    onClicked: {
-                        consoleSerialEditConfirmDialog.close()
-                        consoleSerialInput.text = ""
-                        consoleSerialRow.editing = true
-                        consoleSerialInput.forceActiveFocus()
-                    }
+                    enabled: consoleSerialInput.acceptableInput && consoleSerialInput.text.length > 0
+                    background: Rectangle { color: parent.enabled ? (parent.hovered ? "#E67E22" : "#3A3F4B") : "#2C2F36"; radius: 4; border.color: parent.enabled ? "#E67E22" : "#555" }
+                    contentItem: Text { text: parent.text; color: parent.enabled ? "#E67E22" : "#7F8C8D"; horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter; font.bold: true }
+                    onClicked: MOTIONInterface.writeConsoleSerialNumber(consoleSerialInput.text, true)
                 }
             }
         }

--- a/pages/Console.qml
+++ b/pages/Console.qml
@@ -97,6 +97,7 @@ Rectangle {
     function updateStates() {
         // console.log("Console Updating all states...")
         MOTIONInterface.queryConsoleInfo()
+        MOTIONInterface.readConsoleSerialNumber()
         MOTIONInterface.queryRGBState() // Query Indicator state
         MOTIONInterface.readFanFeedback() // One-shot fan PWM feedback read
         MOTIONInterface.queryConsoleTemperature()
@@ -184,6 +185,18 @@ Rectangle {
             temperature1 = temp1
             temperature2 = temp2
             temperature3 = temp3
+        }
+
+        function onConsoleSerialNumberReceived(serial) {
+            serialCurrent.programmed = (serial.length > 0)
+            serialCurrent.text = serial.length > 0 ? ("Current: " + serial)
+                                                   : "Current: not programmed"
+        }
+        function onConsoleSerialNumberWritten(ok, message) {
+            serialStatus.text = message
+            serialStatus.color = ok ? "lightgreen" : "red"
+            clearSerialStatusTimer.restart()
+            if (ok) serialInput.text = ""
         }
     }
 
@@ -1336,6 +1349,114 @@ Rectangle {
                             }
                         }
                     }
+
+                    // Console Serial Number
+                    Rectangle {
+                        width: 650
+                        height: 150
+                        radius: 8
+                        color: "#1E1E20"
+                        border.color: "#3E4E6F"
+                        border.width: 2
+                        enabled: MOTIONInterface.consoleConnected
+
+                        Text {
+                            id: serialTitle
+                            text: "Console Serial Number"
+                            color: "#BDC3C7"
+                            font.pixelSize: 16
+                            font.bold: true
+                            anchors.top: parent.top
+                            anchors.topMargin: 12
+                            anchors.horizontalCenter: parent.horizontalCenter
+                        }
+
+                        ColumnLayout {
+                            anchors.top: serialTitle.bottom
+                            anchors.topMargin: 12
+                            anchors.left: parent.left
+                            anchors.right: parent.right
+                            anchors.margins: 12
+                            spacing: 10
+
+                            Text {
+                                id: serialCurrent
+                                property bool programmed: false
+                                Layout.fillWidth: true
+                                text: "Current: not programmed"
+                                color: "#3498DB"
+                                font.pixelSize: 13
+                            }
+
+                            RowLayout {
+                                Layout.fillWidth: true
+                                spacing: 12
+
+                                RegularExpressionValidator {
+                                    id: serialValidator
+                                    regularExpression: /^[A-Z0-9]{0,24}$/
+                                }
+
+                                TextField {
+                                    id: serialInput
+                                    Layout.fillWidth: true
+                                    Layout.preferredHeight: 32
+                                    placeholderText: "e.g. QWW04Q10003"
+                                    maximumLength: 24
+                                    validator: serialValidator
+                                    inputMethodHints: Qt.ImhUppercaseOnly
+                                }
+
+                                Button {
+                                    id: serialWriteButton
+                                    text: "Write"
+                                    Layout.preferredWidth: 100
+                                    Layout.preferredHeight: 40
+                                    hoverEnabled: true
+                                    enabled: MOTIONInterface.consoleConnected &&
+                                             serialInput.acceptableInput && serialInput.text.length > 0
+
+                                    contentItem: Text {
+                                        text: parent.text
+                                        color: parent.enabled ? "#BDC3C7" : "#7F8C8D"
+                                        horizontalAlignment: Text.AlignHCenter
+                                        verticalAlignment: Text.AlignVCenter
+                                    }
+                                    background: Rectangle {
+                                        color: parent.hovered ? "#4A90E2" : "#3A3F4B"
+                                        radius: 4
+                                        border.color: parent.hovered ? "#FFFFFF" : "#BDC3C7"
+                                    }
+
+                                    onClicked: {
+                                        if (serialCurrent.programmed) {
+                                            serialConfirmDialog.pending = serialInput.text
+                                            serialConfirmDialog.open()
+                                        } else {
+                                            MOTIONInterface.writeConsoleSerialNumber(serialInput.text, false)
+                                        }
+                                    }
+                                }
+                            }
+
+                            Text {
+                                id: serialStatus
+                                text: ""
+                                color: "#BDC3C7"
+                                font.pixelSize: 12
+                                Layout.fillWidth: true
+                                horizontalAlignment: Text.AlignHCenter
+                            }
+
+                            Timer {
+                                id: clearSerialStatusTimer
+                                interval: 3000
+                                running: false
+                                repeat: false
+                                onTriggered: serialStatus.text = ""
+                            }
+                        }
+                    }
                 }
 
                 // Large Third Column
@@ -1650,6 +1771,60 @@ Rectangle {
                         verticalAlignment: Text.AlignVCenter
                     }
                     onClicked: odometerResetResultDialog.close()
+                }
+            }
+        }
+    }
+
+    // Confirmation for overwriting an already-programmed serial number
+    Dialog {
+        id: serialConfirmDialog
+        title: "Overwrite Serial Number"
+        width: 480
+        height: 220
+        modal: true
+        x: (parent.width - width) / 2
+        y: (parent.height - height) / 2
+
+        property string pending: ""
+
+        ColumnLayout {
+            anchors.fill: parent
+            spacing: 16
+
+            Text {
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
+                color: "#E67E22"
+                font.pixelSize: 14
+                font.bold: true
+                text: "This console already has a serial number (" +
+                      serialCurrent.text.replace("Current: ", "") +
+                      "). Overwrite it with '" + serialConfirmDialog.pending + "'?"
+            }
+
+            RowLayout {
+                Layout.alignment: Qt.AlignRight
+                spacing: 10
+
+                Button {
+                    text: "Cancel"
+                    Layout.preferredWidth: 100
+                    Layout.preferredHeight: 32
+                    background: Rectangle { color: parent.hovered ? "#4A90E2" : "#3A3F4B"; radius: 4; border.color: "#BDC3C7" }
+                    contentItem: Text { text: parent.text; color: "#BDC3C7"; horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter }
+                    onClicked: serialConfirmDialog.close()
+                }
+                Button {
+                    text: "Overwrite"
+                    Layout.preferredWidth: 120
+                    Layout.preferredHeight: 32
+                    background: Rectangle { color: parent.hovered ? "#E67E22" : "#3A3F4B"; radius: 4; border.color: "#E67E22" }
+                    contentItem: Text { text: parent.text; color: "#E67E22"; horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter; font.bold: true }
+                    onClicked: {
+                        serialConfirmDialog.close()
+                        MOTIONInterface.writeConsoleSerialNumber(serialConfirmDialog.pending, true)
+                    }
                 }
             }
         }

--- a/pages/Console.qml
+++ b/pages/Console.qml
@@ -1353,7 +1353,7 @@ Rectangle {
                     // Console Serial Number
                     Rectangle {
                         width: 650
-                        height: 150
+                        height: 160
                         radius: 8
                         color: "#1E1E20"
                         border.color: "#3E4E6F"

--- a/pages/Console.qml
+++ b/pages/Console.qml
@@ -1582,9 +1582,11 @@ Rectangle {
 
 
 
-                        ColumnLayout {
-                            Layout.alignment: Qt.AlignHCenter 
-                            spacing: 25  
+                        GridLayout {
+                            Layout.alignment: Qt.AlignHCenter
+                            columns: 2
+                            columnSpacing: 20
+                            rowSpacing: 20
 
                             // TEMP #1 Widget
                             MiniTemperatureWidget {

--- a/pages/Demo.qml
+++ b/pages/Demo.qml
@@ -1156,7 +1156,12 @@ Rectangle {
                             Component.onCompleted: {
                                 try{
                                     MOTIONInterface.tec_status();
-                                    MOTIONInterface.queryTecTripValue();
+                                    // Only meaningful once connected; the real
+                                    // read happens on connect (consoleUpdateTimer)
+                                    // and on TEC CTRL tab selection.
+                                    if (MOTIONInterface.consoleConnected) {
+                                        MOTIONInterface.queryTecTripValue();
+                                    }
                                 }catch(e){
                                     console.error(e);
                                 }
@@ -1409,10 +1414,13 @@ Rectangle {
                                             Layout.preferredHeight: 30
                                             enabled: MOTIONInterface.consoleConnected
                                             font.pixelSize: 12
-                                            placeholderText: "0-125"
+                                            placeholderText: "1-125"
                                             text: MOTIONInterface.tecTripValue.toString()
                                             inputMethodHints: Qt.ImhDigitsOnly
-                                            validator: IntValidator { bottom: 0; top: 125 }
+                                            // Min is 1, not 0: firmware treats a 0 V trip
+                                            // threshold as "trip disabled", so 0 would
+                                            // silently turn off the over-temp safety.
+                                            validator: IntValidator { bottom: 1; top: 125 }
 
                                             property string tripError: ""
                                             background: Rectangle {
@@ -1425,11 +1433,12 @@ Rectangle {
                                             function applyTrip() {
                                                 var v = parseInt(text)
                                                 if (isNaN(v)) {
-                                                    tripError = "enter 0-125"
+                                                    tripError = "enter 1-125"
                                                     tripErrorTimer.restart()
                                                     return
                                                 }
-                                                if (v < 0) v = 0
+                                                // Clamp to 1 (not 0): 0 disables the trip.
+                                                if (v < 1) v = 1
                                                 if (v > 125) v = 125
                                                 text = v.toString()
                                                 tripError = ""
@@ -2210,6 +2219,10 @@ Rectangle {
                 }
                 
                 updateLaserUI();
+
+                // Refresh the TEC trip temperature now that the console is
+                // connected (the page loads before USB enumeration completes).
+                MOTIONInterface.queryTecTripValue();
             }
             demoLoading = false
         }
@@ -2321,7 +2334,12 @@ Rectangle {
             switch (safetyStack.currentIndex) {
             case 0: break;
             case 1: break;
-            case 2: break;
+            case 2:
+                // TEC CTRL tab: refresh the trip temperature when viewed
+                if (MOTIONInterface.consoleConnected) {
+                    MOTIONInterface.queryTecTripValue();
+                }
+                break;
             }
         }
     }

--- a/pages/Demo.qml
+++ b/pages/Demo.qml
@@ -1156,6 +1156,7 @@ Rectangle {
                             Component.onCompleted: {
                                 try{
                                     MOTIONInterface.tec_status();
+                                    MOTIONInterface.queryTecTripValue();
                                 }catch(e){
                                     console.error(e);
                                 }
@@ -1365,7 +1366,107 @@ Rectangle {
                                                 }
 
 
-                                            }                                        
+                                            }
+                                        }
+                                    }
+                                }
+
+                                // ----- TEC Trip temperature (°C) -----
+                                // Writes the TEC_TRIP key in the console user config;
+                                // firmware converts °C -> thermistor R -> comparator trip V.
+                                Text {
+                                    text: "TEC Trip:"
+                                    color: "white"
+                                    Layout.row: 2
+                                    Layout.column: 0
+                                    Layout.preferredWidth: 100
+                                    Layout.topMargin: 15
+                                    Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
+                                }
+
+                                ColumnLayout {
+                                    Layout.row: 2
+                                    Layout.column: 1
+                                    Layout.columnSpan: 3
+                                    Layout.fillWidth: true
+                                    spacing: 4
+
+                                    Text {
+                                        text: "Trip Temp (°C)"
+                                        color: "#BDC3C7"
+                                        font.pixelSize: 12
+                                    }
+
+                                    RowLayout {
+                                        Layout.fillWidth: true
+                                        spacing: 8
+
+                                        TextField {
+                                            id: tecTripField
+                                            Layout.preferredWidth: 80
+                                            Layout.minimumWidth: 80
+                                            Layout.maximumWidth: 80
+                                            Layout.preferredHeight: 30
+                                            enabled: MOTIONInterface.consoleConnected
+                                            font.pixelSize: 12
+                                            placeholderText: "0-125"
+                                            text: MOTIONInterface.tecTripValue.toString()
+                                            inputMethodHints: Qt.ImhDigitsOnly
+                                            validator: IntValidator { bottom: 0; top: 125 }
+
+                                            property string tripError: ""
+                                            background: Rectangle {
+                                                radius: 6
+                                                color: "#2B2B2E"
+                                                border.color: tecTripField.tripError ? "#E74C3C" : "#555"
+                                                border.width: tecTripField.tripError ? 2 : 1
+                                            }
+
+                                            function applyTrip() {
+                                                var v = parseInt(text)
+                                                if (isNaN(v)) {
+                                                    tripError = "enter 0-125"
+                                                    tripErrorTimer.restart()
+                                                    return
+                                                }
+                                                if (v < 0) v = 0
+                                                if (v > 125) v = 125
+                                                text = v.toString()
+                                                tripError = ""
+                                                if (!MOTIONInterface.setTecTrip(v)) {
+                                                    console.error("Failed to set TEC trip temperature")
+                                                }
+                                            }
+
+                                            onAccepted: applyTrip()
+                                        }
+
+                                        // inline error feedback
+                                        Text {
+                                            text: tecTripField.tripError
+                                            visible: tecTripField.tripError.length > 0
+                                            color: "#E74C3C"
+                                            font.pixelSize: 11
+                                            Layout.alignment: Qt.AlignVCenter
+                                        }
+
+                                        Timer {
+                                            id: tripErrorTimer
+                                            interval: 2500
+                                            onTriggered: tecTripField.tripError = ""
+                                        }
+
+                                        // spacer pushes the button to the far right
+                                        Item { Layout.fillWidth: true }
+
+                                        ActionButton {
+                                            id: btnTecTrip
+                                            text: "Set Trip"
+                                            Layout.alignment: Qt.AlignRight
+                                            Layout.rightMargin: 30
+                                            Layout.preferredWidth: 100
+                                            enabled: MOTIONInterface.consoleConnected
+                                            onTriggered: tecTripField.applyTrip()
                                         }
                                     }
                                 }
@@ -2179,6 +2280,16 @@ Rectangle {
 
         function onTecDacChanged() {
             // console.log("DAC Changed")
+        }
+
+        function onTecTripValueChanged() {
+            // Refresh the field after an async read or a successful write
+            tecTripField.text = MOTIONInterface.tecTripValue.toString()
+        }
+
+        function onTecTripSetFailed(msg) {
+            tecTripField.tripError = msg
+            tripErrorTimer.restart()
         }
 
         // Apply FPGA scale overrides whenever user config is (re)loaded from device

--- a/pages/Sensor.qml
+++ b/pages/Sensor.qml
@@ -177,9 +177,8 @@ Rectangle {
         function onSensorSerialNumberReceived(target, serial) {
             var tgt = (sensorSelector.currentIndex === 0) ? "left" : "right"
             if (target !== tgt) return
-            sensorSerialCurrent.programmed = (serial.length > 0)
-            sensorSerialCurrent.text = serial.length > 0 ? ("Current: " + serial)
-                                                         : "Current: not programmed"
+            sensorSerialValue.programmed = (serial.length > 0)
+            sensorSerialValue.text = serial.length > 0 ? serial : "not programmed"
         }
         function onSensorSerialNumberWritten(target, ok, message) {
             var tgt = (sensorSelector.currentIndex === 0) ? "left" : "right"
@@ -187,7 +186,10 @@ Rectangle {
             sensorSerialStatus.text = message
             sensorSerialStatus.color = ok ? "lightgreen" : "red"
             clearSensorSerialStatusTimer.restart()
-            if (ok) sensorSerialInput.text = ""
+            if (ok) {
+                sensorSerialInput.text = ""
+                sensorSerialRow.editing = false
+            }
         }
 
         // Handle temperature updates
@@ -1818,10 +1820,11 @@ Rectangle {
                                     // Clear fan control status
                                     fanControlOn = false;
 
-                                    // Clear serial box so stale value doesn't linger
-                                    sensorSerialCurrent.text = "Current: not programmed"
-                                    sensorSerialCurrent.programmed = false
+                                    // Clear serial row so stale value doesn't linger
+                                    sensorSerialValue.text = "not programmed"
+                                    sensorSerialValue.programmed = false
                                     sensorSerialInput.text = ""
+                                    sensorSerialRow.editing = false
 
                                     // Fetch new sensor states
                                     updateStates()
@@ -1910,126 +1913,142 @@ Rectangle {
                             Text { text: deviceId; color: "#3498DB"; font.pixelSize: 14 }
                         }
 
+                        // Serial Number — matches the Device ID row, with a pencil to edit
+                        ColumnLayout {
+                            id: sensorSerialRow
+                            property bool editing: false
+                            Layout.fillWidth: true
+                            spacing: 6
+
+                            // Display mode: label + value + pencil
+                            RowLayout {
+                                spacing: 8
+                                visible: !sensorSerialRow.editing
+
+                                Text { text: "Serial Number:"; color: "#BDC3C7"; font.pixelSize: 14 }
+                                Text {
+                                    id: sensorSerialValue
+                                    property bool programmed: false
+                                    text: "not programmed"
+                                    color: "#3498DB"
+                                    font.pixelSize: 14
+                                }
+
+                                // Pencil edit affordance
+                                Text {
+                                    id: sensorSerialEditIcon
+                                    text: "✎"  // pencil
+                                    font.pixelSize: 16
+                                    font.family: iconFont.name
+                                    color: sensorSerialPencilMouse.containsMouse ? "#FFFFFF" : "#BDC3C7"
+                                    visible: (sensorSelector.currentIndex === 0) ? MOTIONInterface.leftSensorConnected
+                                                                                 : MOTIONInterface.rightSensorConnected
+
+                                    MouseArea {
+                                        id: sensorSerialPencilMouse
+                                        anchors.fill: parent
+                                        hoverEnabled: true
+                                        cursorShape: Qt.PointingHandCursor
+                                        onClicked: sensorSerialEditConfirmDialog.open()
+                                    }
+                                    ToolTip.visible: sensorSerialPencilMouse.containsMouse
+                                    ToolTip.text: "Edit serial number"
+                                    ToolTip.delay: 400
+                                }
+                            }
+
+                            // Edit mode: revealed only after the user confirms via the pencil
+                            RowLayout {
+                                spacing: 8
+                                visible: sensorSerialRow.editing
+
+                                Text { text: "Serial Number:"; color: "#BDC3C7"; font.pixelSize: 14 }
+
+                                RegularExpressionValidator {
+                                    id: sensorSerialValidator
+                                    regularExpression: /^[A-Z0-9]{0,24}$/
+                                }
+
+                                TextField {
+                                    id: sensorSerialInput
+                                    Layout.preferredWidth: 180
+                                    Layout.preferredHeight: 28
+                                    placeholderText: "e.g. QWW04Q10003"
+                                    maximumLength: 24
+                                    validator: sensorSerialValidator
+                                    inputMethodHints: Qt.ImhUppercaseOnly
+                                }
+
+                                Button {
+                                    text: "Save"
+                                    Layout.preferredWidth: 70
+                                    Layout.preferredHeight: 28
+                                    hoverEnabled: true
+                                    enabled: sensorSerialInput.acceptableInput && sensorSerialInput.text.length > 0
+                                    contentItem: Text {
+                                        text: parent.text
+                                        color: parent.enabled ? "#BDC3C7" : "#7F8C8D"
+                                        horizontalAlignment: Text.AlignHCenter
+                                        verticalAlignment: Text.AlignVCenter
+                                    }
+                                    background: Rectangle {
+                                        color: parent.hovered ? "#4A90E2" : "#3A3F4B"
+                                        radius: 4
+                                        border.color: parent.hovered ? "#FFFFFF" : "#BDC3C7"
+                                    }
+                                    onClicked: {
+                                        var tgt = (sensorSelector.currentIndex === 0) ? "left" : "right"
+                                        MOTIONInterface.writeSensorSerialNumber(tgt, sensorSerialInput.text, true)
+                                    }
+                                }
+
+                                Button {
+                                    text: "Cancel"
+                                    Layout.preferredWidth: 70
+                                    Layout.preferredHeight: 28
+                                    hoverEnabled: true
+                                    contentItem: Text {
+                                        text: parent.text
+                                        color: "#BDC3C7"
+                                        horizontalAlignment: Text.AlignHCenter
+                                        verticalAlignment: Text.AlignVCenter
+                                    }
+                                    background: Rectangle {
+                                        color: parent.hovered ? "#4A90E2" : "#3A3F4B"
+                                        radius: 4
+                                        border.color: "#BDC3C7"
+                                    }
+                                    onClicked: {
+                                        sensorSerialRow.editing = false
+                                        sensorSerialInput.text = ""
+                                    }
+                                }
+                            }
+
+                            // Write result status (auto-clears)
+                            Text {
+                                id: sensorSerialStatus
+                                text: ""
+                                visible: text.length > 0
+                                color: "#BDC3C7"
+                                font.pixelSize: 12
+                            }
+
+                            Timer {
+                                id: clearSensorSerialStatusTimer
+                                interval: 3000
+                                running: false
+                                repeat: false
+                                onTriggered: sensorSerialStatus.text = ""
+                            }
+                        }
+
                         // Display Firmware Version (Smaller Text)
                         RowLayout {
                             spacing: 8
                             Text { text: "Firmware Version:"; color: "#BDC3C7"; font.pixelSize: 14 }
                             Text { text: firmwareVersion; color: "#2ECC71"; font.pixelSize: 14 }
                         }
-
-                        // Sensor Serial Number
-                        Rectangle {
-                            Layout.fillWidth: true
-                            Layout.preferredWidth: 650
-                            Layout.preferredHeight: 160
-                            radius: 8
-                            color: "#1E1E20"
-                            border.color: "#3E4E6F"
-                            border.width: 2
-                            enabled: (sensorSelector.currentIndex === 0) ? MOTIONInterface.leftSensorConnected
-                                                                         : MOTIONInterface.rightSensorConnected
-
-                            Text {
-                                id: sensorSerialTitle
-                                text: "Sensor Serial Number"
-                                color: "#BDC3C7"
-                                font.pixelSize: 16
-                                font.bold: true
-                                anchors.top: parent.top
-                                anchors.topMargin: 12
-                                anchors.horizontalCenter: parent.horizontalCenter
-                            }
-
-                            ColumnLayout {
-                                anchors.top: sensorSerialTitle.bottom
-                                anchors.topMargin: 12
-                                anchors.left: parent.left
-                                anchors.right: parent.right
-                                anchors.margins: 12
-                                spacing: 10
-
-                                Text {
-                                    id: sensorSerialCurrent
-                                    property bool programmed: false
-                                    Layout.fillWidth: true
-                                    text: "Current: not programmed"
-                                    color: "#3498DB"
-                                    font.pixelSize: 13
-                                }
-
-                                RowLayout {
-                                    Layout.fillWidth: true
-                                    spacing: 12
-
-                                    RegularExpressionValidator {
-                                        id: sensorSerialValidator
-                                        regularExpression: /^[A-Z0-9]{0,24}$/
-                                    }
-
-                                    TextField {
-                                        id: sensorSerialInput
-                                        Layout.fillWidth: true
-                                        Layout.preferredHeight: 32
-                                        placeholderText: "e.g. QWW04Q10003"
-                                        maximumLength: 24
-                                        validator: sensorSerialValidator
-                                        inputMethodHints: Qt.ImhUppercaseOnly
-                                    }
-
-                                    Button {
-                                        id: sensorSerialWriteButton
-                                        text: "Write"
-                                        Layout.preferredWidth: 100
-                                        Layout.preferredHeight: 40
-                                        hoverEnabled: true
-                                        enabled: ((sensorSelector.currentIndex === 0) ? MOTIONInterface.leftSensorConnected
-                                                                                      : MOTIONInterface.rightSensorConnected) &&
-                                                 sensorSerialInput.acceptableInput && sensorSerialInput.text.length > 0
-
-                                        contentItem: Text {
-                                            text: parent.text
-                                            color: parent.enabled ? "#BDC3C7" : "#7F8C8D"
-                                            horizontalAlignment: Text.AlignHCenter
-                                            verticalAlignment: Text.AlignVCenter
-                                        }
-                                        background: Rectangle {
-                                            color: parent.hovered ? "#4A90E2" : "#3A3F4B"
-                                            radius: 4
-                                            border.color: parent.hovered ? "#FFFFFF" : "#BDC3C7"
-                                        }
-
-                                        onClicked: {
-                                            var tgt = (sensorSelector.currentIndex === 0) ? "left" : "right"
-                                            if (sensorSerialCurrent.programmed) {
-                                                sensorSerialConfirmDialog.pending = sensorSerialInput.text
-                                                sensorSerialConfirmDialog.target = tgt
-                                                sensorSerialConfirmDialog.open()
-                                            } else {
-                                                MOTIONInterface.writeSensorSerialNumber(tgt, sensorSerialInput.text, false)
-                                            }
-                                        }
-                                    }
-                                }
-
-                                Text {
-                                    id: sensorSerialStatus
-                                    text: ""
-                                    color: "#BDC3C7"
-                                    font.pixelSize: 12
-                                    Layout.fillWidth: true
-                                    horizontalAlignment: Text.AlignHCenter
-                                }
-
-                                Timer {
-                                    id: clearSensorSerialStatusTimer
-                                    interval: 3000
-                                    running: false
-                                    repeat: false
-                                    onTriggered: sensorSerialStatus.text = ""
-                                }
-                            }
-                        }
-
 
                         ColumnLayout {
                             Layout.alignment: Qt.AlignHCenter 
@@ -2107,18 +2126,15 @@ Rectangle {
         }
     }
 
-    // Confirmation for overwriting an already-programmed sensor serial number
+    // Confirmation before editing the sensor serial number (opened by the pencil)
     Dialog {
-        id: sensorSerialConfirmDialog
-        title: "Overwrite Sensor Serial Number"
-        width: 480
-        height: 220
+        id: sensorSerialEditConfirmDialog
+        title: "Change Serial Number"
+        width: 440
+        height: 190
         modal: true
         x: (parent.width - width) / 2
         y: (parent.height - height) / 2
-
-        property string pending: ""
-        property string target: ""
 
         ColumnLayout {
             anchors.fill: parent
@@ -2130,9 +2146,7 @@ Rectangle {
                 color: "#E67E22"
                 font.pixelSize: 14
                 font.bold: true
-                text: "This sensor already has a serial number (" +
-                      sensorSerialCurrent.text.replace("Current: ", "") +
-                      "). Overwrite it with '" + sensorSerialConfirmDialog.pending + "'?"
+                text: "Are you sure you want to change this sensor's serial number?"
             }
 
             RowLayout {
@@ -2145,17 +2159,19 @@ Rectangle {
                     Layout.preferredHeight: 32
                     background: Rectangle { color: parent.hovered ? "#4A90E2" : "#3A3F4B"; radius: 4; border.color: "#BDC3C7" }
                     contentItem: Text { text: parent.text; color: "#BDC3C7"; horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter }
-                    onClicked: sensorSerialConfirmDialog.close()
+                    onClicked: sensorSerialEditConfirmDialog.close()
                 }
                 Button {
-                    text: "Overwrite"
-                    Layout.preferredWidth: 120
+                    text: "Yes, change it"
+                    Layout.preferredWidth: 140
                     Layout.preferredHeight: 32
                     background: Rectangle { color: parent.hovered ? "#E67E22" : "#3A3F4B"; radius: 4; border.color: "#E67E22" }
                     contentItem: Text { text: parent.text; color: "#E67E22"; horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter; font.bold: true }
                     onClicked: {
-                        sensorSerialConfirmDialog.close()
-                        MOTIONInterface.writeSensorSerialNumber(sensorSerialConfirmDialog.target, sensorSerialConfirmDialog.pending, true)
+                        sensorSerialEditConfirmDialog.close()
+                        sensorSerialInput.text = ""
+                        sensorSerialRow.editing = true
+                        sensorSerialInput.forceActiveFocus()
                     }
                 }
             }

--- a/pages/Sensor.qml
+++ b/pages/Sensor.qml
@@ -76,6 +76,7 @@ Rectangle {
         // console.log("Sensor Updating all states for", sensor_tag);
         
         MOTIONInterface.querySensorInfo(sensor_tag)
+        MOTIONInterface.readSensorSerialNumber(sensor_tag)
         MOTIONInterface.querySensorTemperature(sensor_tag)
         MOTIONInterface.querySensorAccelerometer(sensor_tag)
         MOTIONInterface.queryCameraPowerStatus(sensor_tag)
@@ -171,6 +172,22 @@ Rectangle {
         function onSensorDeviceInfoReceived(fwVersion, devId) {
             firmwareVersion = fwVersion
             deviceId = devId
+        }
+
+        function onSensorSerialNumberReceived(target, serial) {
+            var tgt = (sensorSelector.currentIndex === 0) ? "left" : "right"
+            if (target !== tgt) return
+            sensorSerialCurrent.programmed = (serial.length > 0)
+            sensorSerialCurrent.text = serial.length > 0 ? ("Current: " + serial)
+                                                         : "Current: not programmed"
+        }
+        function onSensorSerialNumberWritten(target, ok, message) {
+            var tgt = (sensorSelector.currentIndex === 0) ? "left" : "right"
+            if (target !== tgt) return
+            sensorSerialStatus.text = message
+            sensorSerialStatus.color = ok ? "lightgreen" : "red"
+            clearSensorSerialStatusTimer.restart()
+            if (ok) sensorSerialInput.text = ""
         }
 
         // Handle temperature updates
@@ -1801,6 +1818,11 @@ Rectangle {
                                     // Clear fan control status
                                     fanControlOn = false;
 
+                                    // Clear serial box so stale value doesn't linger
+                                    sensorSerialCurrent.text = "Current: not programmed"
+                                    sensorSerialCurrent.programmed = false
+                                    sensorSerialInput.text = ""
+
                                     // Fetch new sensor states
                                     updateStates()
                                 }
@@ -1895,6 +1917,119 @@ Rectangle {
                             Text { text: firmwareVersion; color: "#2ECC71"; font.pixelSize: 14 }
                         }
 
+                        // Sensor Serial Number
+                        Rectangle {
+                            Layout.fillWidth: true
+                            Layout.preferredWidth: 650
+                            Layout.preferredHeight: 160
+                            radius: 8
+                            color: "#1E1E20"
+                            border.color: "#3E4E6F"
+                            border.width: 2
+                            enabled: (sensorSelector.currentIndex === 0) ? MOTIONInterface.leftSensorConnected
+                                                                         : MOTIONInterface.rightSensorConnected
+
+                            Text {
+                                id: sensorSerialTitle
+                                text: "Sensor Serial Number"
+                                color: "#BDC3C7"
+                                font.pixelSize: 16
+                                font.bold: true
+                                anchors.top: parent.top
+                                anchors.topMargin: 12
+                                anchors.horizontalCenter: parent.horizontalCenter
+                            }
+
+                            ColumnLayout {
+                                anchors.top: sensorSerialTitle.bottom
+                                anchors.topMargin: 12
+                                anchors.left: parent.left
+                                anchors.right: parent.right
+                                anchors.margins: 12
+                                spacing: 10
+
+                                Text {
+                                    id: sensorSerialCurrent
+                                    property bool programmed: false
+                                    Layout.fillWidth: true
+                                    text: "Current: not programmed"
+                                    color: "#3498DB"
+                                    font.pixelSize: 13
+                                }
+
+                                RowLayout {
+                                    Layout.fillWidth: true
+                                    spacing: 12
+
+                                    RegularExpressionValidator {
+                                        id: sensorSerialValidator
+                                        regularExpression: /^[A-Z0-9]{0,24}$/
+                                    }
+
+                                    TextField {
+                                        id: sensorSerialInput
+                                        Layout.fillWidth: true
+                                        Layout.preferredHeight: 32
+                                        placeholderText: "e.g. QWW04Q10003"
+                                        maximumLength: 24
+                                        validator: sensorSerialValidator
+                                        inputMethodHints: Qt.ImhUppercaseOnly
+                                    }
+
+                                    Button {
+                                        id: sensorSerialWriteButton
+                                        text: "Write"
+                                        Layout.preferredWidth: 100
+                                        Layout.preferredHeight: 40
+                                        hoverEnabled: true
+                                        enabled: ((sensorSelector.currentIndex === 0) ? MOTIONInterface.leftSensorConnected
+                                                                                      : MOTIONInterface.rightSensorConnected) &&
+                                                 sensorSerialInput.acceptableInput && sensorSerialInput.text.length > 0
+
+                                        contentItem: Text {
+                                            text: parent.text
+                                            color: parent.enabled ? "#BDC3C7" : "#7F8C8D"
+                                            horizontalAlignment: Text.AlignHCenter
+                                            verticalAlignment: Text.AlignVCenter
+                                        }
+                                        background: Rectangle {
+                                            color: parent.hovered ? "#4A90E2" : "#3A3F4B"
+                                            radius: 4
+                                            border.color: parent.hovered ? "#FFFFFF" : "#BDC3C7"
+                                        }
+
+                                        onClicked: {
+                                            var tgt = (sensorSelector.currentIndex === 0) ? "left" : "right"
+                                            if (sensorSerialCurrent.programmed) {
+                                                sensorSerialConfirmDialog.pending = sensorSerialInput.text
+                                                sensorSerialConfirmDialog.target = tgt
+                                                sensorSerialConfirmDialog.open()
+                                            } else {
+                                                MOTIONInterface.writeSensorSerialNumber(tgt, sensorSerialInput.text, false)
+                                            }
+                                        }
+                                    }
+                                }
+
+                                Text {
+                                    id: sensorSerialStatus
+                                    text: ""
+                                    color: "#BDC3C7"
+                                    font.pixelSize: 12
+                                    Layout.fillWidth: true
+                                    horizontalAlignment: Text.AlignHCenter
+                                }
+
+                                Timer {
+                                    id: clearSensorSerialStatusTimer
+                                    interval: 3000
+                                    running: false
+                                    repeat: false
+                                    onTriggered: sensorSerialStatus.text = ""
+                                }
+                            }
+                        }
+
 
                         ColumnLayout {
                             Layout.alignment: Qt.AlignHCenter 
@@ -1966,6 +2101,61 @@ Rectangle {
                                 ColorAnimation { duration: 200 }
                             }
                         }
+                    }
+                }
+            }
+        }
+    }
+
+    // Confirmation for overwriting an already-programmed sensor serial number
+    Dialog {
+        id: sensorSerialConfirmDialog
+        title: "Overwrite Sensor Serial Number"
+        width: 480
+        height: 220
+        modal: true
+        x: (parent.width - width) / 2
+        y: (parent.height - height) / 2
+
+        property string pending: ""
+        property string target: ""
+
+        ColumnLayout {
+            anchors.fill: parent
+            spacing: 16
+
+            Text {
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
+                color: "#E67E22"
+                font.pixelSize: 14
+                font.bold: true
+                text: "This sensor already has a serial number (" +
+                      sensorSerialCurrent.text.replace("Current: ", "") +
+                      "). Overwrite it with '" + sensorSerialConfirmDialog.pending + "'?"
+            }
+
+            RowLayout {
+                Layout.alignment: Qt.AlignRight
+                spacing: 10
+
+                Button {
+                    text: "Cancel"
+                    Layout.preferredWidth: 100
+                    Layout.preferredHeight: 32
+                    background: Rectangle { color: parent.hovered ? "#4A90E2" : "#3A3F4B"; radius: 4; border.color: "#BDC3C7" }
+                    contentItem: Text { text: parent.text; color: "#BDC3C7"; horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter }
+                    onClicked: sensorSerialConfirmDialog.close()
+                }
+                Button {
+                    text: "Overwrite"
+                    Layout.preferredWidth: 120
+                    Layout.preferredHeight: 32
+                    background: Rectangle { color: parent.hovered ? "#E67E22" : "#3A3F4B"; radius: 4; border.color: "#E67E22" }
+                    contentItem: Text { text: parent.text; color: "#E67E22"; horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter; font.bold: true }
+                    onClicked: {
+                        sensorSerialConfirmDialog.close()
+                        MOTIONInterface.writeSensorSerialNumber(sensorSerialConfirmDialog.target, sensorSerialConfirmDialog.pending, true)
                     }
                 }
             }

--- a/pages/Sensor.qml
+++ b/pages/Sensor.qml
@@ -183,12 +183,10 @@ Rectangle {
         function onSensorSerialNumberWritten(target, ok, message) {
             var tgt = (sensorSelector.currentIndex === 0) ? "left" : "right"
             if (target !== tgt) return
-            sensorSerialStatus.text = message
-            sensorSerialStatus.color = ok ? "lightgreen" : "red"
-            clearSensorSerialStatusTimer.restart()
             if (ok) {
-                sensorSerialInput.text = ""
-                sensorSerialRow.editing = false
+                sensorSerialEditDialog.close()
+            } else {
+                sensorSerialEditStatus.text = message
             }
         }
 
@@ -1820,11 +1818,9 @@ Rectangle {
                                     // Clear fan control status
                                     fanControlOn = false;
 
-                                    // Clear serial row so stale value doesn't linger
+                                    // Clear serial value so stale value doesn't linger
                                     sensorSerialValue.text = "not programmed"
                                     sensorSerialValue.programmed = false
-                                    sensorSerialInput.text = ""
-                                    sensorSerialRow.editing = false
 
                                     // Fetch new sensor states
                                     updateStates()
@@ -1913,133 +1909,39 @@ Rectangle {
                             Text { text: deviceId; color: "#3498DB"; font.pixelSize: 14 }
                         }
 
-                        // Serial Number — matches the Device ID row, with a pencil to edit
-                        ColumnLayout {
-                            id: sensorSerialRow
-                            property bool editing: false
-                            Layout.fillWidth: true
-                            spacing: 6
+                        // Serial Number — matches the Device ID row; pencil opens an edit modal
+                        RowLayout {
+                            spacing: 8
 
-                            // Display mode: label + value + pencil
-                            RowLayout {
-                                spacing: 8
-                                visible: !sensorSerialRow.editing
-
-                                Text { text: "Serial Number:"; color: "#BDC3C7"; font.pixelSize: 14 }
-                                Text {
-                                    id: sensorSerialValue
-                                    property bool programmed: false
-                                    text: "not programmed"
-                                    color: "#3498DB"
-                                    font.pixelSize: 14
-                                }
-
-                                // Pencil edit affordance
-                                Text {
-                                    id: sensorSerialEditIcon
-                                    text: "✎"  // pencil
-                                    font.pixelSize: 16
-                                    font.family: iconFont.name
-                                    color: sensorSerialPencilMouse.containsMouse ? "#FFFFFF" : "#BDC3C7"
-                                    visible: (sensorSelector.currentIndex === 0) ? MOTIONInterface.leftSensorConnected
-                                                                                 : MOTIONInterface.rightSensorConnected
-
-                                    MouseArea {
-                                        id: sensorSerialPencilMouse
-                                        anchors.fill: parent
-                                        hoverEnabled: true
-                                        cursorShape: Qt.PointingHandCursor
-                                        onClicked: sensorSerialEditConfirmDialog.open()
-                                    }
-                                    ToolTip.visible: sensorSerialPencilMouse.containsMouse
-                                    ToolTip.text: "Edit serial number"
-                                    ToolTip.delay: 400
-                                }
-                            }
-
-                            // Edit mode: revealed only after the user confirms via the pencil
-                            RowLayout {
-                                spacing: 8
-                                visible: sensorSerialRow.editing
-
-                                Text { text: "Serial Number:"; color: "#BDC3C7"; font.pixelSize: 14 }
-
-                                RegularExpressionValidator {
-                                    id: sensorSerialValidator
-                                    regularExpression: /^[A-Z0-9]{0,24}$/
-                                }
-
-                                TextField {
-                                    id: sensorSerialInput
-                                    Layout.preferredWidth: 180
-                                    Layout.preferredHeight: 28
-                                    placeholderText: "e.g. QWW04Q10003"
-                                    maximumLength: 24
-                                    validator: sensorSerialValidator
-                                    inputMethodHints: Qt.ImhUppercaseOnly
-                                }
-
-                                Button {
-                                    text: "Save"
-                                    Layout.preferredWidth: 70
-                                    Layout.preferredHeight: 28
-                                    hoverEnabled: true
-                                    enabled: sensorSerialInput.acceptableInput && sensorSerialInput.text.length > 0
-                                    contentItem: Text {
-                                        text: parent.text
-                                        color: parent.enabled ? "#BDC3C7" : "#7F8C8D"
-                                        horizontalAlignment: Text.AlignHCenter
-                                        verticalAlignment: Text.AlignVCenter
-                                    }
-                                    background: Rectangle {
-                                        color: parent.hovered ? "#4A90E2" : "#3A3F4B"
-                                        radius: 4
-                                        border.color: parent.hovered ? "#FFFFFF" : "#BDC3C7"
-                                    }
-                                    onClicked: {
-                                        var tgt = (sensorSelector.currentIndex === 0) ? "left" : "right"
-                                        MOTIONInterface.writeSensorSerialNumber(tgt, sensorSerialInput.text, true)
-                                    }
-                                }
-
-                                Button {
-                                    text: "Cancel"
-                                    Layout.preferredWidth: 70
-                                    Layout.preferredHeight: 28
-                                    hoverEnabled: true
-                                    contentItem: Text {
-                                        text: parent.text
-                                        color: "#BDC3C7"
-                                        horizontalAlignment: Text.AlignHCenter
-                                        verticalAlignment: Text.AlignVCenter
-                                    }
-                                    background: Rectangle {
-                                        color: parent.hovered ? "#4A90E2" : "#3A3F4B"
-                                        radius: 4
-                                        border.color: "#BDC3C7"
-                                    }
-                                    onClicked: {
-                                        sensorSerialRow.editing = false
-                                        sensorSerialInput.text = ""
-                                    }
-                                }
-                            }
-
-                            // Write result status (auto-clears)
+                            Text { text: "Serial Number:"; color: "#BDC3C7"; font.pixelSize: 14 }
                             Text {
-                                id: sensorSerialStatus
-                                text: ""
-                                visible: text.length > 0
-                                color: "#BDC3C7"
-                                font.pixelSize: 12
+                                id: sensorSerialValue
+                                property bool programmed: false
+                                text: "not programmed"
+                                color: "#3498DB"
+                                font.pixelSize: 14
                             }
 
-                            Timer {
-                                id: clearSensorSerialStatusTimer
-                                interval: 3000
-                                running: false
-                                repeat: false
-                                onTriggered: sensorSerialStatus.text = ""
+                            // Pencil opens the edit modal
+                            Text {
+                                id: sensorSerialEditIcon
+                                text: "✎"  // pencil
+                                font.pixelSize: 16
+                                font.family: iconFont.name
+                                color: sensorSerialPencilMouse.containsMouse ? "#FFFFFF" : "#BDC3C7"
+                                visible: (sensorSelector.currentIndex === 0) ? MOTIONInterface.leftSensorConnected
+                                                                             : MOTIONInterface.rightSensorConnected
+
+                                MouseArea {
+                                    id: sensorSerialPencilMouse
+                                    anchors.fill: parent
+                                    hoverEnabled: true
+                                    cursorShape: Qt.PointingHandCursor
+                                    onClicked: sensorSerialEditDialog.open()
+                                }
+                                ToolTip.visible: sensorSerialPencilMouse.containsMouse
+                                ToolTip.text: "Edit serial number"
+                                ToolTip.delay: 400
                             }
                         }
 
@@ -2126,19 +2028,25 @@ Rectangle {
         }
     }
 
-    // Confirmation before editing the sensor serial number (opened by the pencil)
+    // Edit modal: enter a new sensor serial number (opened by the pencil)
     Dialog {
-        id: sensorSerialEditConfirmDialog
+        id: sensorSerialEditDialog
         title: "Change Serial Number"
         width: 440
-        height: 190
+        height: 240
         modal: true
         x: (parent.width - width) / 2
         y: (parent.height - height) / 2
 
+        onOpened: {
+            sensorSerialInput.text = ""
+            sensorSerialEditStatus.text = ""
+            sensorSerialInput.forceActiveFocus()
+        }
+
         ColumnLayout {
             anchors.fill: parent
-            spacing: 16
+            spacing: 14
 
             Text {
                 Layout.fillWidth: true
@@ -2146,7 +2054,34 @@ Rectangle {
                 color: "#E67E22"
                 font.pixelSize: 14
                 font.bold: true
-                text: "Are you sure you want to change this sensor's serial number?"
+                text: "Are you sure you want to change the " +
+                      ((sensorSelector.currentIndex === 0) ? "left" : "right") +
+                      " sensor's serial number? Enter the new value:"
+            }
+
+            RegularExpressionValidator {
+                id: sensorSerialValidator
+                regularExpression: /^[A-Z0-9]{0,24}$/
+            }
+
+            TextField {
+                id: sensorSerialInput
+                Layout.fillWidth: true
+                Layout.preferredHeight: 32
+                placeholderText: "e.g. QWW04Q10003"
+                maximumLength: 24
+                validator: sensorSerialValidator
+                inputMethodHints: Qt.ImhUppercaseOnly
+                onAccepted: if (sensorSerialSaveButton.enabled) sensorSerialSaveButton.clicked()
+            }
+
+            Text {
+                id: sensorSerialEditStatus
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
+                visible: text.length > 0
+                color: "#E74C3C"
+                font.pixelSize: 12
             }
 
             RowLayout {
@@ -2159,19 +2094,19 @@ Rectangle {
                     Layout.preferredHeight: 32
                     background: Rectangle { color: parent.hovered ? "#4A90E2" : "#3A3F4B"; radius: 4; border.color: "#BDC3C7" }
                     contentItem: Text { text: parent.text; color: "#BDC3C7"; horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter }
-                    onClicked: sensorSerialEditConfirmDialog.close()
+                    onClicked: sensorSerialEditDialog.close()
                 }
                 Button {
-                    text: "Yes, change it"
-                    Layout.preferredWidth: 140
+                    id: sensorSerialSaveButton
+                    text: "Save"
+                    Layout.preferredWidth: 120
                     Layout.preferredHeight: 32
-                    background: Rectangle { color: parent.hovered ? "#E67E22" : "#3A3F4B"; radius: 4; border.color: "#E67E22" }
-                    contentItem: Text { text: parent.text; color: "#E67E22"; horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter; font.bold: true }
+                    enabled: sensorSerialInput.acceptableInput && sensorSerialInput.text.length > 0
+                    background: Rectangle { color: parent.enabled ? (parent.hovered ? "#E67E22" : "#3A3F4B") : "#2C2F36"; radius: 4; border.color: parent.enabled ? "#E67E22" : "#555" }
+                    contentItem: Text { text: parent.text; color: parent.enabled ? "#E67E22" : "#7F8C8D"; horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter; font.bold: true }
                     onClicked: {
-                        sensorSerialEditConfirmDialog.close()
-                        sensorSerialInput.text = ""
-                        sensorSerialRow.editing = true
-                        sensorSerialInput.forceActiveFocus()
+                        var tgt = (sensorSelector.currentIndex === 0) ? "left" : "right"
+                        MOTIONInterface.writeSensorSerialNumber(tgt, sensorSerialInput.text, true)
                     }
                 }
             }


### PR DESCRIPTION
Release gate PR: merges `next` into `main` to cut **test-app 1.4.0**.

Mirrors the SDK flow — this `next → main` PR is the release-approval gate; the tag goes on the merge commit on `main` *after* this merges, which triggers `release-build.yml` to build + package the `.exe` and create the GitHub Release.

**Version:** `1.3.5` → **`1.4.0`** (MINOR — adds new engineering-UI surfaces; matches the `1.4.0-dev.*` line `next` was already on).

**SDK:** this app pulls `omotion` from the latest **published** `openmotion-sdk` wheel at CI build time. A clean `1.4.0` tag (no `-dev` suffix) uses the wheel, so this release builds against the just-published **SDK 1.8.0** — whose serial-number API the UI below consumes.

## What's in this release (13 commits ahead of `main`)

### Features
**Device serial number read/write (console + sensor)** — surfaces the new SDK 1.8.0 serial API in the engineering UI:
- Console serial read/write slots + signals in the connector; write field + read-back on the Console page; inline serial row below Device ID with pencil-to-edit + confirm.
- Sensor serial read/write slots + signals; write field + read-back on the Sensor page; inline serial row with pencil-to-edit + confirm.
- Serial entry moved into a centered modal (was inline, overflowed the narrow panel).

**TEC trip temperature configurator**
- TEC trip configurator in the Demo → TEC CTRL tab.
- Reads the TEC trip after the console connects; forbids `trip=0` (which would disable the firmware safety trip).

### UI / layout
- Shrunk sensor gauges 25% and laid out console temp gauges 2-per-row.
- Serial box height headroom (150→160) to avoid status-text clipping.

## After merge
Tag `1.4.0` on the `main` merge commit → `release-build.yml` builds the `.exe` + zip and creates the GitHub Release. (No PyPI step — this is a packaged app, not a library.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
