### PR TITLE
fix: query GitHub releases only on firmware page open + Refresh

### DIFF
--- a/pages/Settings.qml
+++ b/pages/Settings.qml
@@ -122,29 +122,44 @@ Rectangle {
         return Math.round(w)
     }
 
+    // Local device-info queries (UART/USB). Cheap and safe to run on every
+    // connection change and on the post-connect stabilization tick.
     function refreshConsoleInfo() {
-        if (MOTIONInterface.consoleConnected) {
+        if (MOTIONInterface.consoleConnected)
             MOTIONInterface.queryConsoleInfo()
-            MOTIONInterface.queryConsoleLatestVersionInfo()
-        }
     }
 
     function refreshFpgaInfo() {
-        if (MOTIONInterface.consoleConnected) {
+        if (MOTIONInterface.consoleConnected)
             MOTIONInterface.queryFpgaVersions()
-            MOTIONInterface.queryConsoleLatestFpgaVersionInfo()
-        }
     }
 
     function refreshSensorInfo(target) {
-        if (target === "left" && MOTIONInterface.leftSensorConnected) {
+        if (target === "left" && MOTIONInterface.leftSensorConnected)
             MOTIONInterface.querySensorInfo(target)
-            MOTIONInterface.querySensorLatestVersionInfo(target)
-        }
-        if (target === "right" && MOTIONInterface.rightSensorConnected) {
+        if (target === "right" && MOTIONInterface.rightSensorConnected)
             MOTIONInterface.querySensorInfo(target)
+    }
+
+    // GitHub "latest release" lookups. Each hits the unauthenticated GitHub API
+    // (rate-limited to ~60 req/hr), so these run ONLY when the page is opened
+    // and when the user clicks a Refresh button — never on connection
+    // changes or status polling.
+    function refreshConsoleLatest() {
+        if (MOTIONInterface.consoleConnected)
+            MOTIONInterface.queryConsoleLatestVersionInfo()
+    }
+
+    function refreshFpgaLatest() {
+        if (MOTIONInterface.consoleConnected)
+            MOTIONInterface.queryConsoleLatestFpgaVersionInfo()
+    }
+
+    function refreshSensorLatest(target) {
+        if (target === "left" && MOTIONInterface.leftSensorConnected)
             MOTIONInterface.querySensorLatestVersionInfo(target)
-        }
+        if (target === "right" && MOTIONInterface.rightSensorConnected)
+            MOTIONInterface.querySensorLatestVersionInfo(target)
     }
 
     Connections {
@@ -188,6 +203,8 @@ Rectangle {
             if (MOTIONInterface.consoleConnected || MOTIONInterface.leftSensorConnected || MOTIONInterface.rightSensorConnected) {
                 if (MOTIONInterface.consoleConnected)
                     userConfigLoading = true
+                // Device-info refresh only — leave queryLatestOnTick false so
+                // connection changes/reconnects don't re-hit the GitHub API.
                 settingsInfoTimer.restart()
             } else {
                 settingsInfoTimer.stop()
@@ -397,11 +414,22 @@ Rectangle {
         id: settingsInfoTimer
         interval: 1500
         repeat: false
+        // Set true only when the page is first shown, so the post-settle tick
+        // also pulls the GitHub latest-release info once. Connection-change
+        // restarts leave it false, so reconnects don't re-hit GitHub.
+        property bool queryLatestOnTick: false
         onTriggered: {
             refreshConsoleInfo()
             refreshFpgaInfo()
             refreshSensorInfo("left")
             refreshSensorInfo("right")
+            if (queryLatestOnTick) {
+                refreshConsoleLatest()
+                refreshFpgaLatest()
+                refreshSensorLatest("left")
+                refreshSensorLatest("right")
+                queryLatestOnTick = false
+            }
             if (MOTIONInterface.consoleConnected)
                 MOTIONInterface.readUserConfig()
         }
@@ -412,6 +440,8 @@ Rectangle {
         if (MOTIONInterface.consoleConnected || MOTIONInterface.leftSensorConnected || MOTIONInterface.rightSensorConnected) {
             if (MOTIONInterface.consoleConnected)
                 userConfigLoading = true
+            // One-time GitHub pull when the firmware page opens.
+            settingsInfoTimer.queryLatestOnTick = true
             settingsInfoTimer.start()
         }
     }
@@ -1249,7 +1279,7 @@ Rectangle {
                                     anchors.fill: parent
                                     enabled: parent.enabled
                                     hoverEnabled: true
-                                    onClicked: refreshFpgaInfo()
+                                    onClicked: { refreshFpgaInfo(); refreshFpgaLatest() }
                                     onEntered: if (parent.enabled) parent.color = "#34495E"
                                     onExited: parent.color = parent.enabled ? "#2C3E50" : "#7F8C8D"
                                 }
@@ -1582,7 +1612,7 @@ Rectangle {
                                         anchors.fill: parent
                                         enabled: parent.enabled
                                         hoverEnabled: true
-                                        onClicked: refreshConsoleInfo()
+                                        onClicked: { refreshConsoleInfo(); refreshConsoleLatest() }
                                         onEntered: if (parent.enabled) parent.color = "#34495E"
                                         onExited: parent.color = parent.enabled ? "#2C3E50" : "#7F8C8D"
                                     }
@@ -1727,7 +1757,7 @@ Rectangle {
                                         anchors.fill: parent
                                         enabled: parent.enabled
                                         hoverEnabled: true
-                                        onClicked: refreshSensorInfo("left")
+                                        onClicked: { refreshSensorInfo("left"); refreshSensorLatest("left") }
                                         onEntered: if (parent.enabled) parent.color = "#34495E"
                                         onExited: parent.color = parent.enabled ? "#2C3E50" : "#7F8C8D"
                                     }
@@ -1867,7 +1897,7 @@ Rectangle {
                                         anchors.fill: parent
                                         enabled: parent.enabled
                                         hoverEnabled: true
-                                        onClicked: refreshSensorInfo("right")
+                                        onClicked: { refreshSensorInfo("right"); refreshSensorLatest("right") }
                                         onEntered: if (parent.enabled) parent.color = "#34495E"
                                         onExited: parent.color = parent.enabled ? "#2C3E50" : "#7F8C8D"
                                     }


### PR DESCRIPTION
## Problem

The firmware page (`pages/Settings.qml`) was hitting the GitHub Releases API far too often. The GitHub "latest release" lookups were bundled into the same functions that fetch local device info (`refreshConsoleInfo` / `refreshFpgaInfo` / `refreshSensorInfo`), and those functions run on a 1.5 s stabilization timer that **restarts on every connection-state change** (`onConnectionStatusChanged` → `settingsInfoTimer.restart()`).

Since a single connect passes through `CONNECTING → CONNECTED` (and any reconnect/flap re-fires), and `omotion`'s `GitHubReleases` does **no caching**, each timer fire issued up to ~9 unauthenticated GitHub API requests (console 2 + FPGA 3 + each sensor 2) — quickly exhausting the unauthenticated 60 req/hr limit.

## Fix

Decouple the network lookups from the local device-info queries:

- `refreshConsoleInfo` / `refreshFpgaInfo` / `refreshSensorInfo` → **local UART/USB device queries only**. These stay on the connection-change / settle-tick path (cheap, no network).
- New `refreshConsoleLatest` / `refreshFpgaLatest` / `refreshSensorLatest` → hold the GitHub calls and fire **only** when:
  1. the firmware page is opened (one-shot `queryLatestOnTick` flag, set in `Component.onCompleted`, consumed and cleared on the first settle tick), and
  2. the user clicks one of the four **Refresh** buttons.

Connection-change `restart()`s leave `queryLatestOnTick` false, so reconnects no longer re-hit GitHub.

## Behavior note

Implemented to spec: GitHub is queried on page-open and on Refresh, nothing else. If you open the firmware page while a module is **disconnected** and then connect it, that section's latest-release column stays `N/A` until you click its Refresh button (the page-open pull already ran with nothing connected). Easy to extend to a one-shot pull on first connect if desired.

## Testing

- `pyside6-qmllint pages/Settings.qml` — no syntax errors (only pre-existing context-property warnings for `MOTIONInterface`).
- Verified by inspection that the three GitHub slots (`queryConsoleLatestVersionInfo`, `queryConsoleLatestFpgaVersionInfo`, `querySensorLatestVersionInfo`) are now reachable only via the new `*Latest` functions, which are called only from the page-open tick and the Refresh buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)