### PR TITLE
fix: About/README said OpenLIFU instead of Open-Motion

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Python example UI for OPEN Motion used for Hardware Testing and Basic Usage
 - **Python 3.9 or later**: Make sure you have Python 3.9 or later installed on your system. You can download it from the [official Python website](https://www.python.org/downloads/).
 
 ### Steps to Set Up the Project
-1. **Install OpenLIFU Python**
+1. **Install the OpenMOTION SDK (`omotion` Python library)**
    ```bash
-   https://github.com/OpenwaterHealth/OpenMOTION-Pylib
-   cd OpenMOTION-Pylib
-   pip install -r requirements.txt
+   git clone https://github.com/OpenwaterHealth/openmotion-sdk.git
+   cd openmotion-sdk
+   pip install .
    ```
 
 2. **Clone the repository and Install Required Packages**:
@@ -32,7 +32,7 @@ Python example UI for OPEN Motion used for Hardware Testing and Basic Usage
    ```
 
 3. **Run application**
-   requires OpenMOTION-Pylib to be installed or referenced prior to running main.py
+   requires the OpenMOTION SDK (`omotion`) to be installed or referenced prior to running main.py
 
    ```bash
    cd OpenMOTION-TestAPP

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Python example UI for OPEN Motion used for Hardware Testing and Basic Usage
 - **Python 3.9 or later**: Make sure you have Python 3.9 or later installed on your system. You can download it from the [official Python website](https://www.python.org/downloads/).
 
 ### Steps to Set Up the Project
-1. **Install the OpenMOTION SDK (`omotion` Python library)**
+1. **Install the Open-Motion SDK (`omotion` Python library)**
    ```bash
    git clone https://github.com/OpenwaterHealth/openmotion-sdk.git
    cd openmotion-sdk
@@ -32,7 +32,7 @@ Python example UI for OPEN Motion used for Hardware Testing and Basic Usage
    ```
 
 3. **Run application**
-   requires the OpenMOTION SDK (`omotion`) to be installed or referenced prior to running main.py
+   requires the Open-Motion SDK (`omotion`) to be installed or referenced prior to running main.py
 
    ```bash
    cd OpenMOTION-TestAPP


### PR DESCRIPTION
Fixes OpenwaterHealth/openmotion-sdk#35

## What the issue actually pointed at
Issue openmotion-sdk#35 ("About information says open-LIFU instead of Open-Motion") was filed against the SDK, but the SDK repo contains **no** LIFU references — its only ones ever (the demo-mode `b"Hello LIFU!"` echo strings) were removed in `f520525` on 2026-04-08 and shipped in SDK 1.5.0, a week *before* the issue was filed. PyPI metadata and the GitHub repo description are also clean (verified by case-insensitive grep of the full tree incl. UTF-16 byte scan, `git log -S lifu --all`, and the PyPI JSON for both package names).

The one remaining user-visible LIFU reference in the project family is **this repo's README**, whose setup section (the "about" a visitor reads first) said **"Install OpenLIFU Python"** — a copy-paste leftover from the OpenLIFU test app.

## Changes (README.md only)
- Step 1: "Install OpenLIFU Python" → "Install the OpenMOTION SDK (`omotion` Python library)", with a working `git clone https://github.com/OpenwaterHealth/openmotion-sdk.git` (the old block had a bare URL with no `git clone`, and pointed at the retired OpenMOTION-Pylib name).
- Run-application note: "requires OpenMOTION-Pylib" → "requires the OpenMOTION SDK (`omotion`)" for consistency.

## Verification
`grep -rniE lifu` across the worktree (excluding .git) now returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)