### PR TITLE
fix: bump pytest to 9.0.3 (Dependabot GHSA-6w46-j5rx-g56g)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ PyInstaller==6.15.0
 pandas==2.3.3
 numpy>=1.24.0
 # Optional tools for development and testing
-pytest==7.4.0
+pytest==9.0.3
 flake8==7.1.1


### PR DESCRIPTION
Resolves the open medium-severity Dependabot alert on `requirements.txt`: pytest < 9.0.3 (GHSA-6w46-j5rx-g56g).

Two-major-version jump (7.4.0 → 9.0.3), verified against the repo's test suite in a clean venv with pytest 9.0.3: all 6 tests in `tests/test_log_setup.py` collect and pass. pytest is a dev/test-only dependency (listed under the optional-tools section), so the packaged app is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)